### PR TITLE
restructure: kzg module

### DIFF
--- a/src/kem.rs
+++ b/src/kem.rs
@@ -133,226 +133,227 @@ impl From<KZGError> for KEMError {
 
 #[cfg(test)]
 mod tests {
-    // use super::*;
-    // use crate::pol_op::evaluate_polynomial;
-    // use ark_bls12_381::{Bls12_381, Fr, G1Projective, G2Projective};
-    // use ark_std::test_rng;
-    // use ark_std::UniformRand;
+    use super::*;
+    use crate::pol_op::evaluate_polynomial;
+    use ark_bls12_381::G1Projective;
+    use ark_bls12_381::{Bls12_381, Fr};
+    use ark_std::test_rng;
+    use ark_std::UniformRand;
 
-    // #[test]
-    // fn test_encapsulation_decapsulation() {
-    //     let rng = &mut test_rng();
-    //     let g1_gen = G1Projective::rand(rng);
-    //     let g2_gen = G2Projective::rand(rng);
-    //     let secret = Fr::rand(rng);
-    //     let max_degree = 10;
-    //     let point: Fr = Fr::rand(rng);
-    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+    #[test]
+    fn test_encapsulation_decapsulation() {
+        let rng = &mut test_rng();
+        let secret = Fr::rand(rng);
+        let max_degree = 10;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-    //     let p = vec![
-    //         Fr::from(-24),
-    //         Fr::from(-25),
-    //         Fr::from(-5),
-    //         Fr::from(9),
-    //         Fr::from(7),
-    //     ];
-    //     let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-    //     let commitment = kzg.commit(&p).unwrap();
+        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+        let p = vec![
+            Fr::from(-24),
+            Fr::from(-25),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
 
-    //     // Encapsulate
-    //     let (ciphertext, mut enc_key) = encapsulate(&kzg, commitment, point, val).unwrap();
-    //     let mut enc_key_bytes = [0u8; 32];
-    //     enc_key.fill(&mut enc_key_bytes);
+        let point: Fr = Fr::rand(rng);
+        let eval = evaluate_polynomial::<Bls12_381>(&p, &point);
+        let commitment = kzg.commit(&p).unwrap();
 
-    //     // Decapsulate
-    //     let proof = kzg.open(&p, &point).unwrap();
-    //     let mut dec_key = decapsulate::<Bls12_381>(proof, ciphertext).unwrap();
-    //     let mut dec_key_bytes = [0u8; 32];
-    //     dec_key.fill(&mut dec_key_bytes);
+        // Encapsulate
+        let (ciphertext, mut enc_key) = encapsulate(&kzg, commitment, point, eval).unwrap();
+        let mut enc_key_bytes = [0u8; 32];
+        enc_key.fill(&mut enc_key_bytes);
 
-    //     assert_eq!(enc_key_bytes, dec_key_bytes);
-    // }
+        // Decapsulate
+        let proof = kzg.open(&p, &point).unwrap();
+        let mut dec_key = decapsulate::<Bls12_381>(proof, ciphertext).unwrap();
+        let mut dec_key_bytes = [0u8; 32];
+        dec_key.fill(&mut dec_key_bytes);
 
-    // #[test]
-    // fn test_decapsulation_invalid_proof() {
-    //     let rng = &mut test_rng();
-    //     let g1_gen = G1Projective::rand(rng);
-    //     let g2_gen = G2Projective::rand(rng);
-    //     let secret = Fr::rand(rng);
-    //     let max_degree = 10;
-    //     let point: Fr = Fr::rand(rng);
-    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+        // Assert that the keys match
+        assert_eq!(enc_key_bytes, dec_key_bytes);
+    }
 
-    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-    //     let p = vec![
-    //         Fr::from(-24),
-    //         Fr::from(-25),
-    //         Fr::from(-5),
-    //         Fr::from(9),
-    //         Fr::from(7),
-    //     ];
-    //     let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-    //     let commitment = kzg.commit(&p).unwrap();
+    #[test]
+    fn test_decapsulation_invalid_proof() {
+        let rng = &mut test_rng();
+        let secret = Fr::rand(rng);
+        let max_degree = 10;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-    //     // Encapsulate
-    //     let (ciphertext, mut enc_key) =
-    //         encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
-    //     let mut enc_key_bytes = [0u8; 32];
-    //     enc_key.fill(&mut enc_key_bytes);
+        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+        let p = vec![
+            Fr::from(-24),
+            Fr::from(-25),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
 
-    //     // Generate an invalid proof
-    //     let wrong_point: Fr = Fr::rand(rng);
-    //     let invalid_proof = kzg.open(&p, &wrong_point).unwrap();
+        let point: Fr = Fr::rand(rng);
+        let eval = evaluate_polynomial::<Bls12_381>(&p, &point);
+        let commitment = kzg.commit(&p).unwrap();
 
-    //     // Attempt to decapsulate with the invalid proof
-    //     let mut dec_key = decapsulate::<Bls12_381>(invalid_proof, ciphertext).unwrap();
-    //     let mut dec_key_bytes = [0u8; 32];
-    //     dec_key.fill(&mut dec_key_bytes);
+        // Encapsulate
+        let (ciphertext, mut enc_key) =
+            encapsulate::<Bls12_381>(&kzg, commitment, point, eval).unwrap();
+        let mut enc_key_bytes = [0u8; 32];
+        enc_key.fill(&mut enc_key_bytes);
 
-    //     // The keys should not match
-    //     assert_ne!(enc_key_bytes, dec_key_bytes);
-    // }
+        // Decapsulate with a different polynomial
+        // q(x) = 7 x^4 + 9 x^3 - 5 x^2 - 29 x - 24
+        let q = vec![
+            Fr::from(-24),
+            Fr::from(-29),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
 
-    // #[test]
-    // fn test_decapsulation_invalid_ciphertext() {
-    //     let rng = &mut test_rng();
-    //     let g1_gen = G1Projective::rand(rng);
-    //     let g2_gen = G2Projective::rand(rng);
-    //     let secret = Fr::rand(rng);
-    //     let max_degree = 10;
-    //     let point: Fr = Fr::rand(rng);
-    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+        let invalid_proof = kzg.open(&q, &point).unwrap();
+        let mut dec_key = decapsulate::<Bls12_381>(invalid_proof, ciphertext).unwrap();
+        let mut dec_key_bytes = [0u8; 32];
+        dec_key.fill(&mut dec_key_bytes);
 
-    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-    //     let p = vec![
-    //         Fr::from(-24),
-    //         Fr::from(-25),
-    //         Fr::from(-5),
-    //         Fr::from(9),
-    //         Fr::from(7),
-    //     ];
-    //     let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-    //     let commitment = kzg.commit(&p).unwrap();
+        // Keys should not match
+        assert_ne!(enc_key_bytes, dec_key_bytes);
+    }
 
-    //     // Encapsulate
-    //     let (ciphertext, mut enc_key) =
-    //         encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
-    //     let mut enc_key_bytes = [0u8; 32];
-    //     enc_key.fill(&mut enc_key_bytes);
+    #[test]
+    fn test_decapsulation_invalid_ciphertext() {
+        let rng = &mut test_rng();
+        let secret = Fr::rand(rng);
+        let max_degree = 10;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-    //     // Generate an invalid ciphertext (e.g., by using a different random value)
-    //     let invalid_ciphertext = ciphertext.mul(Fr::rand(rng));
+        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+        let p = vec![
+            Fr::from(-24),
+            Fr::from(-25),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
+        let point: Fr = Fr::rand(rng);
+        let val = evaluate_polynomial::<Bls12_381>(&p, &point);
+        let commitment = kzg.commit(&p).unwrap();
 
-    //     // Attempt to decapsulate with the invalid ciphertext
-    //     let proof = kzg.open(&p, &point).unwrap();
+        // Encapsulate
+        let (ciphertext, mut enc_key) =
+            encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
+        let mut enc_key_bytes = [0u8; 32];
+        enc_key.fill(&mut enc_key_bytes);
 
-    //     let mut dec_key = decapsulate::<Bls12_381>(proof, invalid_ciphertext).unwrap();
-    //     let mut dec_key_bytes = [0u8; 32];
-    //     dec_key.fill(&mut dec_key_bytes);
+        // Generate an random ciphertext
+        let invalid_ciphertext = ciphertext.mul(Fr::rand(rng));
 
-    //     // The keys should not match
-    //     assert_ne!(enc_key_bytes, dec_key_bytes);
-    // }
+        // Attempt to decapsulate with the invalid ciphertext
+        let proof = kzg.open(&p, &point).unwrap();
 
-    // #[test]
-    // fn test_decapsulation_wrong_proof_ciphertext() {
-    //     let rng = &mut test_rng();
-    //     let g1_gen = G1Projective::rand(rng);
-    //     let g2_gen = G2Projective::rand(rng);
-    //     let secret = Fr::rand(rng);
-    //     let max_degree = 10;
-    //     let point1: Fr = Fr::rand(rng);
-    //     let point2: Fr = Fr::rand(rng);
-    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+        let mut dec_key = decapsulate::<Bls12_381>(proof, invalid_ciphertext).unwrap();
+        let mut dec_key_bytes = [0u8; 32];
+        dec_key.fill(&mut dec_key_bytes);
 
-    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-    //     let p = vec![
-    //         Fr::from(-24),
-    //         Fr::from(-25),
-    //         Fr::from(-5),
-    //         Fr::from(9),
-    //         Fr::from(7),
-    //     ];
-    //     let val1 = evaluate_polynomial::<Bls12_381>(&p, &point1);
-    //     let commitment = kzg.commit(&p).unwrap();
+        // Keys should not match
+        assert_ne!(enc_key_bytes, dec_key_bytes);
+    }
 
-    //     // Encapsulate with point1
-    //     let (ciphertext1, mut enc_key) =
-    //         encapsulate::<Bls12_381>(&kzg, commitment, point1, val1).unwrap();
-    //     let mut enc_key_bytes = [0u8; 32];
-    //     enc_key.fill(&mut enc_key_bytes);
+    #[test]
+    fn test_decapsulation_wrong_point() {
+        let rng = &mut test_rng();
+        let secret = Fr::rand(rng);
+        let max_degree = 10;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-    //     // Proof for point2
-    //     let proof2 = kzg.open(&p, &point2).unwrap();
+        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+        let p = vec![
+            Fr::from(-24),
+            Fr::from(-25),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
 
-    //     // Decapsulate with proof for point2
-    //     let mut dec_key = decapsulate::<Bls12_381>(proof2, ciphertext1).unwrap();
-    //     let mut dec_key_bytes = [0u8; 32];
-    //     dec_key.fill(&mut dec_key_bytes);
+        let point1: Fr = Fr::rand(rng);
+        let val1 = evaluate_polynomial::<Bls12_381>(&p, &point1);
+        let commitment = kzg.commit(&p).unwrap();
 
-    //     // Keys should not match
-    //     assert_ne!(enc_key_bytes, dec_key_bytes);
-    // }
+        // Encapsulate with point1
+        let (ciphertext1, mut enc_key) =
+            encapsulate::<Bls12_381>(&kzg, commitment, point1, val1).unwrap();
+        let mut enc_key_bytes = [0u8; 32];
+        enc_key.fill(&mut enc_key_bytes);
 
-    // #[test]
-    // fn test_encapsulate_decapsulate_set() {
-    //     let rng = &mut test_rng();
-    //     let g1_gen = G1Projective::rand(rng);
-    //     let g2_gen = G2Projective::rand(rng);
-    //     let secret = Fr::rand(rng);
-    //     let max_degree = 10;
-    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+        // Proof for point2
+        let point2: Fr = Fr::rand(rng);
+        let proof2 = kzg.open(&p, &point2).unwrap();
 
-    //     // Define the polynomial p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-    //     let p = vec![
-    //         Fr::from(-24),
-    //         Fr::from(-25),
-    //         Fr::from(-5),
-    //         Fr::from(9),
-    //         Fr::from(7),
-    //     ];
-    //     let commitment = kzg.commit(&p).unwrap();
+        // Decapsulate with proof for point2
+        let mut dec_key = decapsulate::<Bls12_381>(proof2, ciphertext1).unwrap();
+        let mut dec_key_bytes = [0u8; 32];
+        dec_key.fill(&mut dec_key_bytes);
 
-    //     // Define points and their corresponding values
-    //     let points = vec![Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
-    //     let values: Vec<Fr> = points
-    //         .iter()
-    //         .map(|point| evaluate_polynomial::<Bls12_381>(&p, point))
-    //         .collect();
+        // Keys should not match
+        assert_ne!(enc_key_bytes, dec_key_bytes);
+    }
 
-    //     // Encapsulate the set
-    //     let (ciphertexts, mut enc_keys) =
-    //         encapsulate_set::<Bls12_381>(&kzg, commitment, &points, &values).unwrap();
-    //     let enc_keys_bytes: Vec<[u8; 32]> = enc_keys
-    //         .iter_mut()
-    //         .map(|enc_key| {
-    //             let mut enc_key_bytes = [0u8; 32];
-    //             enc_key.fill(&mut enc_key_bytes);
-    //             enc_key_bytes
-    //         })
-    //         .collect();
+    #[test]
+    fn test_encapsulate_decapsulate_set() {
+        let rng = &mut test_rng();
+        let secret = Fr::rand(rng);
+        let max_degree = 10;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-    //     // Generate proofs for the points
-    //     let proofs: Vec<G1Projective> = points
-    //         .iter()
-    //         .map(|point| kzg.open(&p, point).unwrap())
-    //         .collect();
+        // Define the polynomial p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+        let p = vec![
+            Fr::from(-24),
+            Fr::from(-25),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
+        let commitment = kzg.commit(&p).unwrap();
 
-    //     // Decapsulate the set
-    //     let mut dec_keys = decapsulate_set::<Bls12_381>(&proofs, &ciphertexts).unwrap();
-    //     let dec_keys_bytes: Vec<[u8; 32]> = dec_keys
-    //         .iter_mut()
-    //         .map(|dec_key| {
-    //             let mut dec_key_bytes = [0u8; 32];
-    //             dec_key.fill(&mut dec_key_bytes);
-    //             dec_key_bytes
-    //         })
-    //         .collect();
+        // Define points and their corresponding values
+        let points = vec![Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
+        let values: Vec<Fr> = points
+            .iter()
+            .map(|point| evaluate_polynomial::<Bls12_381>(&p, point))
+            .collect();
 
-    //     // Compare the encapsulated and decapsulated keys
-    //     for (enc_key_bytes, dec_key_bytes) in enc_keys_bytes.iter().zip(dec_keys_bytes.iter()) {
-    //         assert_eq!(enc_key_bytes, dec_key_bytes);
-    //     }
-    // }
+        // Encapsulate the set
+        let (ciphertexts, mut enc_keys) =
+            encapsulate_set::<Bls12_381>(&kzg, commitment, &points, &values).unwrap();
+        let enc_keys_bytes: Vec<[u8; 32]> = enc_keys
+            .iter_mut()
+            .map(|enc_key| {
+                let mut enc_key_bytes = [0u8; 32];
+                enc_key.fill(&mut enc_key_bytes);
+                enc_key_bytes
+            })
+            .collect();
+
+        // Generate proofs for the points
+        let proofs: Vec<G1Projective> = points
+            .iter()
+            .map(|point| kzg.open(&p, point).unwrap())
+            .collect();
+
+        // Decapsulate the set
+        let mut dec_keys = decapsulate_set::<Bls12_381>(&proofs, &ciphertexts).unwrap();
+        let dec_keys_bytes: Vec<[u8; 32]> = dec_keys
+            .iter_mut()
+            .map(|dec_key| {
+                let mut dec_key_bytes = [0u8; 32];
+                dec_key.fill(&mut dec_key_bytes);
+                dec_key_bytes
+            })
+            .collect();
+
+        // Compare the encapsulated and decapsulated keys
+        for (enc_key_bytes, dec_key_bytes) in enc_keys_bytes.iter().zip(dec_keys_bytes.iter()) {
+            assert_eq!(enc_key_bytes, dec_key_bytes);
+        }
+    }
 }

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -135,17 +135,19 @@ impl From<KZGError> for KEMError {
 mod tests {
     use super::*;
     use crate::pol_op::evaluate_polynomial;
-    use ark_bls12_381::G1Projective;
-    use ark_bls12_381::{Bls12_381, Fr};
-    use ark_std::test_rng;
-    use ark_std::UniformRand;
+    use ark_bls12_381::{Bls12_381, Fr, G1Projective};
+    use ark_std::{test_rng, UniformRand};
+    use rand::Rng;
+
+    fn setup_kzg(rng: &mut impl Rng) -> KZG<Bls12_381> {
+        let secret = Fr::rand(rng);
+        KZG::<Bls12_381>::setup(secret, 10)
+    }
 
     #[test]
     fn test_encapsulation_decapsulation() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -178,9 +180,7 @@ mod tests {
     #[test]
     fn test_decapsulation_invalid_proof() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -223,9 +223,7 @@ mod tests {
     #[test]
     fn test_decapsulation_invalid_ciphertext() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -262,9 +260,7 @@ mod tests {
     #[test]
     fn test_decapsulation_wrong_point() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -301,9 +297,7 @@ mod tests {
     #[test]
     fn test_encapsulate_decapsulate_set() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
 
         // Define the polynomial p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![

--- a/src/kem.rs
+++ b/src/kem.rs
@@ -2,9 +2,9 @@
 //!
 //! This module implements the **Extractable Witness Key Encapsulation Mechanism** functions.
 
-use crate::kzg::KZG;
+use crate::kzg::{g1_gen, g2_gen, KZGError, KZG};
 use ark_ec::pairing::Pairing;
-use ark_serialize::{CanonicalSerialize, SerializationError};
+use ark_serialize::CanonicalSerialize;
 use ark_std::{rand, UniformRand};
 use blake3::OutputReader;
 use rand::thread_rng;
@@ -20,7 +20,7 @@ pub fn encapsulate<E: Pairing>(
     value: E::ScalarField,
 ) -> Result<(E::G2, OutputReader), KEMError> {
     // [beta]_1
-    let value_in_g1: E::G1 = kzg.g1_gen().mul(value);
+    let value_in_g1: E::G1 = g1_gen::<E>().mul(value);
 
     // (com - [beta]_1)
     let com_beta = commitment - value_in_g1;
@@ -32,15 +32,15 @@ pub fn encapsulate<E: Pairing>(
 
     // Calculate secret
     // s = e(r * (com - [beta]_1), g2)
-    let secret = E::pairing(com_beta.mul(r), kzg.g2_gen());
+    let secret = E::pairing(com_beta.mul(r), g2_gen::<E>());
     let mut secret_bytes = Vec::<u8>::new();
     secret
         .serialize_uncompressed(&mut secret_bytes)
-        .map_err(KEMError::SerializationError)?;
+        .map_err(|e| KEMError::SerializationError(e.to_string()))?;
 
     // Calculate a ciphertext to share the randomness used in the encapsulation.
     // ct = r([tau]_2 - [alpha]_2)
-    let tau_alpha: E::G2 = kzg.tau_g2() - kzg.g2_gen().mul(point);
+    let tau_alpha: E::G2 = kzg.tau_g2()? - g2_gen::<E>().mul(point);
     let ciphertext: E::G2 = tau_alpha.mul(r);
 
     // Generate the key
@@ -65,7 +65,7 @@ pub fn decapsulate<E: Pairing>(proof: E::G1, ciphertext: E::G2) -> Result<Output
     let mut secret_bytes = Vec::<u8>::new();
     secret
         .serialize_uncompressed(&mut secret_bytes)
-        .map_err(KEMError::SerializationError)?;
+        .map_err(|e| KEMError::SerializationError(e.to_string()))?;
 
     // Get the key
     // k = H(s)
@@ -113,238 +113,246 @@ pub fn decapsulate_set<E: Pairing>(
         .collect()
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum KEMError {
     #[error("Proofs and ciphertexts sets must have the same length")]
     DecapsulationInputsLengthError,
     #[error("Points and values sets must have the same length")]
     EncapsulationInputsLengthError,
+    #[error("KZG error: {0}")]
+    KZGError(KZGError),
     #[error("Secret serialization failed {0}")]
-    SerializationError(SerializationError),
+    SerializationError(String),
+}
+
+impl From<KZGError> for KEMError {
+    fn from(err: KZGError) -> Self {
+        KEMError::KZGError(err)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::pol_op::evaluate_polynomial;
-    use ark_bls12_381::{Bls12_381, Fr, G1Projective, G2Projective};
-    use ark_std::test_rng;
-    use ark_std::UniformRand;
+    // use super::*;
+    // use crate::pol_op::evaluate_polynomial;
+    // use ark_bls12_381::{Bls12_381, Fr, G1Projective, G2Projective};
+    // use ark_std::test_rng;
+    // use ark_std::UniformRand;
 
-    #[test]
-    fn test_encapsulation_decapsulation() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let point: Fr = Fr::rand(rng);
-        let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+    // #[test]
+    // fn test_encapsulation_decapsulation() {
+    //     let rng = &mut test_rng();
+    //     let g1_gen = G1Projective::rand(rng);
+    //     let g2_gen = G2Projective::rand(rng);
+    //     let secret = Fr::rand(rng);
+    //     let max_degree = 10;
+    //     let point: Fr = Fr::rand(rng);
+    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
 
-        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-        let commitment = kzg.commit(&p).unwrap();
+    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+    //     let p = vec![
+    //         Fr::from(-24),
+    //         Fr::from(-25),
+    //         Fr::from(-5),
+    //         Fr::from(9),
+    //         Fr::from(7),
+    //     ];
+    //     let val = evaluate_polynomial::<Bls12_381>(&p, &point);
+    //     let commitment = kzg.commit(&p).unwrap();
 
-        // Encapsulate
-        let (ciphertext, mut enc_key) = encapsulate(&kzg, commitment, point, val).unwrap();
-        let mut enc_key_bytes = [0u8; 32];
-        enc_key.fill(&mut enc_key_bytes);
+    //     // Encapsulate
+    //     let (ciphertext, mut enc_key) = encapsulate(&kzg, commitment, point, val).unwrap();
+    //     let mut enc_key_bytes = [0u8; 32];
+    //     enc_key.fill(&mut enc_key_bytes);
 
-        // Decapsulate
-        let proof = kzg.open(&p, &point).unwrap();
-        let mut dec_key = decapsulate::<Bls12_381>(proof, ciphertext).unwrap();
-        let mut dec_key_bytes = [0u8; 32];
-        dec_key.fill(&mut dec_key_bytes);
+    //     // Decapsulate
+    //     let proof = kzg.open(&p, &point).unwrap();
+    //     let mut dec_key = decapsulate::<Bls12_381>(proof, ciphertext).unwrap();
+    //     let mut dec_key_bytes = [0u8; 32];
+    //     dec_key.fill(&mut dec_key_bytes);
 
-        assert_eq!(enc_key_bytes, dec_key_bytes);
-    }
+    //     assert_eq!(enc_key_bytes, dec_key_bytes);
+    // }
 
-    #[test]
-    fn test_decapsulation_invalid_proof() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let point: Fr = Fr::rand(rng);
-        let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+    // #[test]
+    // fn test_decapsulation_invalid_proof() {
+    //     let rng = &mut test_rng();
+    //     let g1_gen = G1Projective::rand(rng);
+    //     let g2_gen = G2Projective::rand(rng);
+    //     let secret = Fr::rand(rng);
+    //     let max_degree = 10;
+    //     let point: Fr = Fr::rand(rng);
+    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
 
-        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-        let commitment = kzg.commit(&p).unwrap();
+    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+    //     let p = vec![
+    //         Fr::from(-24),
+    //         Fr::from(-25),
+    //         Fr::from(-5),
+    //         Fr::from(9),
+    //         Fr::from(7),
+    //     ];
+    //     let val = evaluate_polynomial::<Bls12_381>(&p, &point);
+    //     let commitment = kzg.commit(&p).unwrap();
 
-        // Encapsulate
-        let (ciphertext, mut enc_key) =
-            encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
-        let mut enc_key_bytes = [0u8; 32];
-        enc_key.fill(&mut enc_key_bytes);
+    //     // Encapsulate
+    //     let (ciphertext, mut enc_key) =
+    //         encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
+    //     let mut enc_key_bytes = [0u8; 32];
+    //     enc_key.fill(&mut enc_key_bytes);
 
-        // Generate an invalid proof
-        let wrong_point: Fr = Fr::rand(rng);
-        let invalid_proof = kzg.open(&p, &wrong_point).unwrap();
+    //     // Generate an invalid proof
+    //     let wrong_point: Fr = Fr::rand(rng);
+    //     let invalid_proof = kzg.open(&p, &wrong_point).unwrap();
 
-        // Attempt to decapsulate with the invalid proof
-        let mut dec_key = decapsulate::<Bls12_381>(invalid_proof, ciphertext).unwrap();
-        let mut dec_key_bytes = [0u8; 32];
-        dec_key.fill(&mut dec_key_bytes);
+    //     // Attempt to decapsulate with the invalid proof
+    //     let mut dec_key = decapsulate::<Bls12_381>(invalid_proof, ciphertext).unwrap();
+    //     let mut dec_key_bytes = [0u8; 32];
+    //     dec_key.fill(&mut dec_key_bytes);
 
-        // The keys should not match
-        assert_ne!(enc_key_bytes, dec_key_bytes);
-    }
+    //     // The keys should not match
+    //     assert_ne!(enc_key_bytes, dec_key_bytes);
+    // }
 
-    #[test]
-    fn test_decapsulation_invalid_ciphertext() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let point: Fr = Fr::rand(rng);
-        let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+    // #[test]
+    // fn test_decapsulation_invalid_ciphertext() {
+    //     let rng = &mut test_rng();
+    //     let g1_gen = G1Projective::rand(rng);
+    //     let g2_gen = G2Projective::rand(rng);
+    //     let secret = Fr::rand(rng);
+    //     let max_degree = 10;
+    //     let point: Fr = Fr::rand(rng);
+    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
 
-        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-        let commitment = kzg.commit(&p).unwrap();
+    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+    //     let p = vec![
+    //         Fr::from(-24),
+    //         Fr::from(-25),
+    //         Fr::from(-5),
+    //         Fr::from(9),
+    //         Fr::from(7),
+    //     ];
+    //     let val = evaluate_polynomial::<Bls12_381>(&p, &point);
+    //     let commitment = kzg.commit(&p).unwrap();
 
-        // Encapsulate
-        let (ciphertext, mut enc_key) =
-            encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
-        let mut enc_key_bytes = [0u8; 32];
-        enc_key.fill(&mut enc_key_bytes);
+    //     // Encapsulate
+    //     let (ciphertext, mut enc_key) =
+    //         encapsulate::<Bls12_381>(&kzg, commitment, point, val).unwrap();
+    //     let mut enc_key_bytes = [0u8; 32];
+    //     enc_key.fill(&mut enc_key_bytes);
 
-        // Generate an invalid ciphertext (e.g., by using a different random value)
-        let invalid_ciphertext = ciphertext.mul(Fr::rand(rng));
+    //     // Generate an invalid ciphertext (e.g., by using a different random value)
+    //     let invalid_ciphertext = ciphertext.mul(Fr::rand(rng));
 
-        // Attempt to decapsulate with the invalid ciphertext
-        let proof = kzg.open(&p, &point).unwrap();
+    //     // Attempt to decapsulate with the invalid ciphertext
+    //     let proof = kzg.open(&p, &point).unwrap();
 
-        let mut dec_key = decapsulate::<Bls12_381>(proof, invalid_ciphertext).unwrap();
-        let mut dec_key_bytes = [0u8; 32];
-        dec_key.fill(&mut dec_key_bytes);
+    //     let mut dec_key = decapsulate::<Bls12_381>(proof, invalid_ciphertext).unwrap();
+    //     let mut dec_key_bytes = [0u8; 32];
+    //     dec_key.fill(&mut dec_key_bytes);
 
-        // The keys should not match
-        assert_ne!(enc_key_bytes, dec_key_bytes);
-    }
+    //     // The keys should not match
+    //     assert_ne!(enc_key_bytes, dec_key_bytes);
+    // }
 
-    #[test]
-    fn test_decapsulation_wrong_proof_ciphertext() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let point1: Fr = Fr::rand(rng);
-        let point2: Fr = Fr::rand(rng);
-        let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+    // #[test]
+    // fn test_decapsulation_wrong_proof_ciphertext() {
+    //     let rng = &mut test_rng();
+    //     let g1_gen = G1Projective::rand(rng);
+    //     let g2_gen = G2Projective::rand(rng);
+    //     let secret = Fr::rand(rng);
+    //     let max_degree = 10;
+    //     let point1: Fr = Fr::rand(rng);
+    //     let point2: Fr = Fr::rand(rng);
+    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
 
-        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let val1 = evaluate_polynomial::<Bls12_381>(&p, &point1);
-        let commitment = kzg.commit(&p).unwrap();
+    //     // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+    //     let p = vec![
+    //         Fr::from(-24),
+    //         Fr::from(-25),
+    //         Fr::from(-5),
+    //         Fr::from(9),
+    //         Fr::from(7),
+    //     ];
+    //     let val1 = evaluate_polynomial::<Bls12_381>(&p, &point1);
+    //     let commitment = kzg.commit(&p).unwrap();
 
-        // Encapsulate with point1
-        let (ciphertext1, mut enc_key) =
-            encapsulate::<Bls12_381>(&kzg, commitment, point1, val1).unwrap();
-        let mut enc_key_bytes = [0u8; 32];
-        enc_key.fill(&mut enc_key_bytes);
+    //     // Encapsulate with point1
+    //     let (ciphertext1, mut enc_key) =
+    //         encapsulate::<Bls12_381>(&kzg, commitment, point1, val1).unwrap();
+    //     let mut enc_key_bytes = [0u8; 32];
+    //     enc_key.fill(&mut enc_key_bytes);
 
-        // Proof for point2
-        let proof2 = kzg.open(&p, &point2).unwrap();
+    //     // Proof for point2
+    //     let proof2 = kzg.open(&p, &point2).unwrap();
 
-        // Decapsulate with proof for point2
-        let mut dec_key = decapsulate::<Bls12_381>(proof2, ciphertext1).unwrap();
-        let mut dec_key_bytes = [0u8; 32];
-        dec_key.fill(&mut dec_key_bytes);
+    //     // Decapsulate with proof for point2
+    //     let mut dec_key = decapsulate::<Bls12_381>(proof2, ciphertext1).unwrap();
+    //     let mut dec_key_bytes = [0u8; 32];
+    //     dec_key.fill(&mut dec_key_bytes);
 
-        // Keys should not match
-        assert_ne!(enc_key_bytes, dec_key_bytes);
-    }
+    //     // Keys should not match
+    //     assert_ne!(enc_key_bytes, dec_key_bytes);
+    // }
 
-    #[test]
-    fn test_encapsulate_decapsulate_set() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
+    // #[test]
+    // fn test_encapsulate_decapsulate_set() {
+    //     let rng = &mut test_rng();
+    //     let g1_gen = G1Projective::rand(rng);
+    //     let g2_gen = G2Projective::rand(rng);
+    //     let secret = Fr::rand(rng);
+    //     let max_degree = 10;
+    //     let kzg: KZG<Bls12_381> = KZG::setup(g1_gen, g2_gen, max_degree, secret);
 
-        // Define the polynomial p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let commitment = kzg.commit(&p).unwrap();
+    //     // Define the polynomial p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+    //     let p = vec![
+    //         Fr::from(-24),
+    //         Fr::from(-25),
+    //         Fr::from(-5),
+    //         Fr::from(9),
+    //         Fr::from(7),
+    //     ];
+    //     let commitment = kzg.commit(&p).unwrap();
 
-        // Define points and their corresponding values
-        let points = vec![Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
-        let values: Vec<Fr> = points
-            .iter()
-            .map(|point| evaluate_polynomial::<Bls12_381>(&p, point))
-            .collect();
+    //     // Define points and their corresponding values
+    //     let points = vec![Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
+    //     let values: Vec<Fr> = points
+    //         .iter()
+    //         .map(|point| evaluate_polynomial::<Bls12_381>(&p, point))
+    //         .collect();
 
-        // Encapsulate the set
-        let (ciphertexts, mut enc_keys) =
-            encapsulate_set::<Bls12_381>(&kzg, commitment, &points, &values).unwrap();
-        let enc_keys_bytes: Vec<[u8; 32]> = enc_keys
-            .iter_mut()
-            .map(|enc_key| {
-                let mut enc_key_bytes = [0u8; 32];
-                enc_key.fill(&mut enc_key_bytes);
-                enc_key_bytes
-            })
-            .collect();
+    //     // Encapsulate the set
+    //     let (ciphertexts, mut enc_keys) =
+    //         encapsulate_set::<Bls12_381>(&kzg, commitment, &points, &values).unwrap();
+    //     let enc_keys_bytes: Vec<[u8; 32]> = enc_keys
+    //         .iter_mut()
+    //         .map(|enc_key| {
+    //             let mut enc_key_bytes = [0u8; 32];
+    //             enc_key.fill(&mut enc_key_bytes);
+    //             enc_key_bytes
+    //         })
+    //         .collect();
 
-        // Generate proofs for the points
-        let proofs: Vec<G1Projective> = points
-            .iter()
-            .map(|point| kzg.open(&p, point).unwrap())
-            .collect();
+    //     // Generate proofs for the points
+    //     let proofs: Vec<G1Projective> = points
+    //         .iter()
+    //         .map(|point| kzg.open(&p, point).unwrap())
+    //         .collect();
 
-        // Decapsulate the set
-        let mut dec_keys = decapsulate_set::<Bls12_381>(&proofs, &ciphertexts).unwrap();
-        let dec_keys_bytes: Vec<[u8; 32]> = dec_keys
-            .iter_mut()
-            .map(|dec_key| {
-                let mut dec_key_bytes = [0u8; 32];
-                dec_key.fill(&mut dec_key_bytes);
-                dec_key_bytes
-            })
-            .collect();
+    //     // Decapsulate the set
+    //     let mut dec_keys = decapsulate_set::<Bls12_381>(&proofs, &ciphertexts).unwrap();
+    //     let dec_keys_bytes: Vec<[u8; 32]> = dec_keys
+    //         .iter_mut()
+    //         .map(|dec_key| {
+    //             let mut dec_key_bytes = [0u8; 32];
+    //             dec_key.fill(&mut dec_key_bytes);
+    //             dec_key_bytes
+    //         })
+    //         .collect();
 
-        // Compare the encapsulated and decapsulated keys
-        for (enc_key_bytes, dec_key_bytes) in enc_keys_bytes.iter().zip(dec_keys_bytes.iter()) {
-            assert_eq!(enc_key_bytes, dec_key_bytes);
-        }
-    }
+    //     // Compare the encapsulated and decapsulated keys
+    //     for (enc_key_bytes, dec_key_bytes) in enc_keys_bytes.iter().zip(dec_keys_bytes.iter()) {
+    //         assert_eq!(enc_key_bytes, dec_key_bytes);
+    //     }
+    // }
 }

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -208,8 +208,7 @@ impl From<SetupFileError> for KZGError {
 mod tests {
     use super::*;
     use ark_bls12_381::{Bls12_381, Config as BLS12Config, Fr, G1Projective};
-    use ark_ec::bls12::Bls12Config;
-    use ark_ec::short_weierstrass::SWCurveConfig;
+    use ark_ec::{bls12::Bls12Config, short_weierstrass::SWCurveConfig};
     use ark_ff::UniformRand;
     use ark_std::test_rng;
 

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -5,55 +5,47 @@
 pub mod setup;
 
 use crate::pol_op::*;
-use ark_ec::pairing::Pairing;
+use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_ff::{Field, Zero};
+use setup::{get_powers_from_file, SetupFileError};
 use std::ops::Mul;
 use thiserror::Error;
 
 /// KZG polynomial commitment scheme.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct KZG<E: Pairing> {
-    /// G1 generator
-    g1_gen: E::G1,
-    /// G2 generator
-    g2_gen: E::G2,
     /// Powers of tau in G1 - [tau^i]_1
     g1_pow: Vec<E::G1>,
     /// Powers of tau in G2 - [tau^i]_2
     g2_pow: Vec<E::G2>,
-    /// Tau in G2 - [tau]_2
-    tau_g2: E::G2,
-    /// Maximum degree
-    max_d: usize,
 }
 
 impl<E: Pairing> KZG<E> {
-    /// Initializes the KZG commitment scheme.
-    pub fn setup(g1_gen: E::G1, g2_gen: E::G2, max_d: usize, secret: E::ScalarField) -> Self {
-        let tau_g2 = g2_gen.mul(secret);
+    /// Initializes the KZG commitment scheme from a trusted setup file.
+    pub fn new_from_file(file: &str) -> Result<Self, KZGError> {
+        let (g1_pow, g2_pow) = get_powers_from_file::<E>(file)?;
+
+        Ok(Self { g1_pow, g2_pow })
+    }
+
+    /// Initializes the KZG commitment scheme from a given secret.
+    /// This is recommended for **testing purposes only**, since it requires the secret to be known.
+    pub fn setup(secret: E::ScalarField, max_d: usize) -> Self {
         let mut g1_pow = Vec::with_capacity(max_d + 1);
         let mut g2_pow = Vec::with_capacity(max_d + 1);
 
-        // Generate powers of tau for G1
         for i in 0..=max_d {
-            g1_pow.push(g1_gen.mul(secret.pow([i as u64])));
-            g2_pow.push(g2_gen.mul(secret.pow([i as u64])));
+            g1_pow.push(g1_gen::<E>().mul(secret.pow([i as u64])));
+            g2_pow.push(g2_gen::<E>().mul(secret.pow([i as u64])));
         }
 
-        Self {
-            g1_gen,
-            g2_gen,
-            g1_pow,
-            g2_pow,
-            tau_g2,
-            max_d,
-        }
+        Self { g1_pow, g2_pow }
     }
 
     /// Commits to a polynomial.
     pub fn commit(&self, p: &[E::ScalarField]) -> Result<E::G1, KZGError> {
-        if p.len() > self.max_d + 1 {
-            return Err(KZGError::PolynomialTooLarge);
+        if p.len() > self.g1_pow.len() {
+            return Err(KZGError::PolynomialTooLarge(p.len(), self.g1_pow.len()));
         }
 
         let mut commitment = E::G1::zero();
@@ -69,10 +61,6 @@ impl<E: Pairing> KZG<E> {
 
     /// Computes an opening (proof) for a polynomial at a point.
     pub fn open(&self, p: &[E::ScalarField], point: &E::ScalarField) -> Result<E::G1, KZGError> {
-        if p.len() > self.max_d + 1 {
-            return Err(KZGError::PolynomialTooLarge);
-        }
-
         let value = evaluate_polynomial::<E>(p, point);
 
         // p(x) - p(point)
@@ -94,16 +82,24 @@ impl<E: Pairing> KZG<E> {
         point: E::ScalarField,
         value: E::ScalarField,
         proof: E::G1,
-    ) -> bool {
+    ) -> Result<bool, KZGError> {
         // [beta]_1
-        let value_in_g1 = self.g1_gen.mul(value);
+        let value_in_g1 = g1_gen::<E>().mul(value);
+
+        // [tau]_2
+        let tau_in_g2 = self.tau_g2()?;
+
+        // [1]_2
+        let g2_gen = g2_gen::<E>();
 
         // [alpha]_2
-        let point_in_g2 = self.g2_gen.mul(point);
+        let point_in_g2 = g2_gen.mul(point);
 
         // e(commitment - [beta]_1, [1]_2) == e(proof, [tau]_2 - [alpha]_2)
-        E::pairing(commitment - value_in_g1, self.g2_gen)
-            == E::pairing(proof, self.tau_g2 - point_in_g2)
+        let v = E::pairing(commitment - value_in_g1, g2_gen)
+            == E::pairing(proof, tau_in_g2 - point_in_g2);
+
+        Ok(v)
     }
 
     /// Computes a batch opening for a polynomial at multiple points.
@@ -112,10 +108,6 @@ impl<E: Pairing> KZG<E> {
         p: &[E::ScalarField],
         points: &[E::ScalarField],
     ) -> Result<E::G1, KZGError> {
-        if p.len() > self.max_d + 1 {
-            return Err(KZGError::PolynomialTooLarge);
-        }
-
         // Evaluate the polynomial at the points
         let mut values = Vec::with_capacity(points.len());
         for point in points.iter() {
@@ -160,21 +152,11 @@ impl<E: Pairing> KZG<E> {
         // Commit to the Lagrange polynomial in G1
         let lagrange_p_com = self.commit(&lagrange_p)?;
 
-        let res =
-            // e(commitment - [lagrange_p]_1, [1]_2) == e(proof, [zero_p]_2)
-            E::pairing(commitment - lagrange_p_com, self.g2_gen) == E::pairing(proof, zero_p_com);
+        // e(commitment - [lagrange_p]_1, [1]_2) == e(proof, [zero_p]_2)
+        let v =
+            E::pairing(commitment - lagrange_p_com, g2_gen::<E>()) == E::pairing(proof, zero_p_com);
 
-        Ok(res)
-    }
-
-    /// Returns the generator in G1.
-    pub fn g1_gen(&self) -> E::G1 {
-        self.g1_gen
-    }
-
-    /// Returns the generator in G2.
-    pub fn g2_gen(&self) -> E::G2 {
-        self.g2_gen
+        Ok(v)
     }
 
     /// Returns the powers of tau in G1.
@@ -182,23 +164,32 @@ impl<E: Pairing> KZG<E> {
         &self.g1_pow
     }
 
-    /// Returns the tau in G2.
-    pub fn tau_g2(&self) -> E::G2 {
-        self.tau_g2
-    }
-
-    /// Returns the maximum degree.
-    pub fn max_degree(&self) -> usize {
-        self.max_d
+    /// Returns [tau]_2
+    pub fn tau_g2(&self) -> Result<E::G2, KZGError> {
+        self.g2_pow.get(1).copied().ok_or(KZGError::G2PowersEmpty)
     }
 }
 
-#[derive(Error, Debug)]
+/// Returns the G1 generator in projective coordinates.
+pub fn g1_gen<E: Pairing>() -> E::G1 {
+    E::G1Affine::generator().into()
+}
+
+/// Returns the G2 generator in projective coordinates.
+pub fn g2_gen<E: Pairing>() -> E::G2 {
+    E::G2Affine::generator().into()
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum KZGError {
-    #[error("Polynomial exceeds the maximum degree")]
-    PolynomialTooLarge,
+    #[error("G2 powers of tau are empty")]
+    G2PowersEmpty,
     #[error("Operation error: {0}")]
     OperationError(OperationError),
+    #[error("Can't commit to polynomial: polynomial has degree {0} but max degree is {1}")]
+    PolynomialTooLarge(usize, usize),
+    #[error("Setup file error: {0}")]
+    SetupFileError(SetupFileError),
 }
 
 impl From<OperationError> for KZGError {
@@ -207,64 +198,69 @@ impl From<OperationError> for KZGError {
     }
 }
 
+impl From<SetupFileError> for KZGError {
+    fn from(err: SetupFileError) -> Self {
+        KZGError::SetupFileError(err)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_bls12_381::{
-        g1::{G1_GENERATOR_X, G1_GENERATOR_Y},
-        g2::{G2_GENERATOR_X, G2_GENERATOR_Y},
-        Bls12_381, Fr, G1Affine, G1Projective, G2Affine, G2Projective,
-    };
+    use ark_bls12_381::{Bls12_381, Config as BLS12Config, Fr, G1Projective};
+    use ark_ec::bls12::Bls12Config;
+    use ark_ec::short_weierstrass::SWCurveConfig;
     use ark_ff::UniformRand;
     use ark_std::test_rng;
 
     #[test]
     fn test_kzg_setup() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 10;
         let secret = Fr::rand(rng);
+        let max_degree = 3;
 
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-        // Verify G1 powers
+        // G1
         assert_eq!(kzg.g1_pow.len(), max_degree + 1);
         for i in 0..=max_degree {
-            assert_eq!(kzg.g1_pow[i], g1_generator.mul(secret.pow([i as u64])));
+            assert_eq!(
+                kzg.g1_pow[i],
+                g1_gen::<Bls12_381>().mul(secret.pow([i as u64]))
+            );
         }
 
-        // Verify tau in G2
-        assert_eq!(kzg.tau_g2, g2_generator.mul(secret));
+        // G2
+        assert_eq!(kzg.g2_pow.len(), max_degree + 1);
+        for i in 0..=max_degree {
+            assert_eq!(
+                kzg.g2_pow[i],
+                g2_gen::<Bls12_381>().mul(secret.pow([i as u64]))
+            );
+        }
+
+        // [tau]_2
+        assert_eq!(kzg.tau_g2().unwrap(), g2_gen::<Bls12_381>().mul(secret));
     }
 
     #[test]
-    fn test_kzg_setup_min_degree() {
-        let rng = &mut test_rng();
-        let g1_generator = G1Projective::rand(rng);
-        let g2_generator = G2Projective::rand(rng);
-        let max_degree = 0;
-        let secret = Fr::rand(rng);
+    fn test_generators() {
+        let expected_g1_gen = <BLS12Config as Bls12Config>::G1Config::GENERATOR;
+        let expected_g2_gen = <BLS12Config as Bls12Config>::G2Config::GENERATOR;
 
-        let kzg = KZG::<Bls12_381>::setup(g1_generator, g2_generator, max_degree, secret);
+        let g1_gen = g1_gen::<Bls12_381>();
+        let g2_gen = g2_gen::<Bls12_381>();
 
-        assert_eq!(kzg.g1_pow.len(), 1);
-        assert_eq!(kzg.g1_pow[0], g1_generator.mul(secret.pow([0])));
-
-        assert_eq!(kzg.tau_g2, g2_generator.mul(secret));
+        assert_eq!(g1_gen, expected_g1_gen);
+        assert_eq!(g2_gen, expected_g2_gen);
     }
 
     #[test]
     fn test_kzg_commit() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 2;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 2;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // 2 x^2 + 3 x + 1
         let p = vec![Fr::from(1), Fr::from(3), Fr::from(2)];
@@ -279,67 +275,54 @@ mod tests {
     }
 
     #[test]
-    fn test_kzg_commit_zero_polynomial() {
-        let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 2;
-        let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
-
-        let zero_polynomial = vec![Fr::zero(); max_degree + 1];
-        let commitment = kzg.commit(&zero_polynomial).unwrap();
-
-        assert_eq!(commitment, G1Projective::zero());
-    }
-
-    #[test]
     fn test_kzg_commit_polynomial_too_large() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 2;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 2;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         let p = vec![Fr::from(1), Fr::from(3), Fr::from(2), Fr::from(4)];
 
         let result = kzg.commit(&p);
-        assert!(matches!(result, Err(KZGError::PolynomialTooLarge)));
+        let expected_err = KZGError::PolynomialTooLarge(p.len(), max_degree + 1);
+
+        assert_eq!(result, Err(expected_err));
     }
 
     #[test]
     fn test_kzg_open_polynomial_too_large() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 2;
         let secret = Fr::rand(rng);
+        let max_degree = 2;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
-
-        let p = vec![Fr::from(1), Fr::from(3), Fr::from(2), Fr::from(4)];
+        let p = vec![
+            Fr::from(1),
+            Fr::from(2),
+            Fr::from(3),
+            Fr::from(4),
+            Fr::from(5),
+            Fr::from(6),
+        ];
         let point = Fr::from(5);
 
+        let value = evaluate_polynomial::<Bls12_381>(&p, &point);
+        let numerator = subtract_polynomials::<Bls12_381>(&p, &[value]);
+        let denominator = [-point, <Bls12_381 as Pairing>::ScalarField::ONE];
+        let quotient = divide_polynomials::<Bls12_381>(&numerator, &denominator).unwrap();
+
         let result = kzg.open(&p, &point);
-        assert!(matches!(result, Err(KZGError::PolynomialTooLarge)));
+        let expected_err = KZGError::PolynomialTooLarge(quotient.len(), max_degree + 1);
+
+        assert_eq!(result, Err(expected_err));
     }
 
     #[test]
     fn test_kzg_open_and_verify() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 2;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 2;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // 2 x^2 + 3 x + 1
         let p = vec![Fr::from(1), Fr::from(3), Fr::from(2)];
@@ -352,19 +335,19 @@ mod tests {
 
         let proof = kzg.open(&p, &point).unwrap();
 
-        assert!(kzg.verify(commitment, point, expected_value, proof));
+        let v = kzg
+            .verify(commitment, point, expected_value, proof)
+            .unwrap();
+
+        assert!(v);
     }
 
     #[test]
-    fn test_kzg_verify_invalid_opening() {
+    fn test_kzg_verify_wrong_alpha() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -376,30 +359,30 @@ mod tests {
         ];
 
         let commitment = kzg.commit(&p).unwrap();
-
         let point = Fr::from(11);
 
         // p(11) = 113562
         let expected_value = Fr::from(113562);
 
         let proof = kzg.open(&p, &point).unwrap();
+        let v_valid_point = kzg
+            .verify(commitment, point, expected_value, proof)
+            .unwrap();
+        assert_eq!(v_valid_point, true);
 
         let wrong_point = Fr::from(99);
-
-        assert!(!kzg.verify(commitment, wrong_point, expected_value, proof));
-        assert!(kzg.verify(commitment, point, expected_value, proof));
+        let v_wrong_point = kzg
+            .verify(commitment, wrong_point, expected_value, proof)
+            .unwrap();
+        assert_eq!(v_wrong_point, false);
     }
 
     #[test]
-    fn test_kzg_verify_invalid_value() {
+    fn test_kzg_verify_wrong_beta() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -418,23 +401,22 @@ mod tests {
         let expected_value = Fr::from(10662);
 
         let proof = kzg.open(&p, &point).unwrap();
+        let v_valid_point = kzg
+            .verify(commitment, point, expected_value, proof)
+            .unwrap();
+        assert_eq!(v_valid_point, true);
 
         let wrong_value = Fr::from(10663);
-
-        assert!(!kzg.verify(commitment, point, wrong_value, proof));
-        assert!(kzg.verify(commitment, point, expected_value, proof));
+        let v_wrong_value = kzg.verify(commitment, point, wrong_value, proof).unwrap();
+        assert_eq!(v_wrong_value, false);
     }
 
     #[test]
-    fn test_kzg_verify_invalid_proof() {
+    fn test_kzg_verify_wrong_proof() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -450,27 +432,31 @@ mod tests {
         let point = Fr::from(6);
 
         // p(6) = 10662
-        let expected_value = Fr::from(10662);
+        let value = Fr::from(10662);
 
-        let correct_proof = kzg.open(&p, &point).unwrap();
+        let proof = kzg.open(&p, &point).unwrap();
+        let v_valid_point = kzg.verify(commitment, point, value, proof).unwrap();
+        assert_eq!(v_valid_point, true);
 
-        let wrong_point = Fr::from(7);
-        let wrong_proof = kzg.open(&p, &wrong_point).unwrap();
-
-        assert!(!kzg.verify(commitment, point, expected_value, wrong_proof));
-        assert!(kzg.verify(commitment, point, expected_value, correct_proof));
+        // Create a proof for a different polynomial
+        let fake_p = vec![
+            Fr::from(-24),
+            Fr::from(-26),
+            Fr::from(-5),
+            Fr::from(9),
+            Fr::from(7),
+        ];
+        let wrong_proof = kzg.open(&fake_p, &point).unwrap();
+        let v_wrong_proof = kzg.verify(commitment, point, value, wrong_proof).unwrap();
+        assert_eq!(v_wrong_proof, false);
     }
 
     #[test]
-    fn test_kzg_verify_invalid_polynomial() {
+    fn test_kzg_verify_wrong_commitment() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -483,60 +469,45 @@ mod tests {
 
         let commitment = kzg.commit(&p).unwrap();
 
-        // p(6) = 10662
         let point = Fr::from(6);
-        let expected_value = Fr::from(10662);
 
-        let correct_proof = kzg.open(&p, &point).unwrap();
+        // p(6) = 10662
+        let value = Fr::from(10662);
 
-        // q(x) = 2 x^4 - 3 x^3 + x^2 + 5 x + 10
-        let q = vec![
-            Fr::from(10),
-            Fr::from(5),
-            Fr::from(1),
-            Fr::from(-3),
-            Fr::from(2),
-        ];
+        let proof = kzg.open(&p, &point).unwrap();
+        let v_valid_commitment = kzg.verify(commitment, point, value, proof).unwrap();
+        assert_eq!(v_valid_commitment, true);
 
-        let fake_proof = kzg.open(&q, &point).unwrap();
-
-        assert!(!kzg.verify(commitment, point, expected_value, fake_proof));
-        assert!(kzg.verify(commitment, point, expected_value, correct_proof));
+        // Create a random commitment
+        let wrong_com = commitment.mul(Fr::from(2));
+        let v_wrong_commitment = kzg.verify(wrong_com, point, value, proof).unwrap();
+        assert_eq!(v_wrong_commitment, false);
     }
 
     #[test]
     fn test_kzg_batch_open_repeated_points() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 3 x^3 + 2 x^2 + x + 1
         let p = vec![Fr::from(1), Fr::from(1), Fr::from(2), Fr::from(3)];
 
         let repeated_points = vec![Fr::from(2), Fr::from(2)];
 
-        let result = kzg.batch_open(&p, &repeated_points);
-        assert!(matches!(
-            result,
-            Err(KZGError::OperationError(OperationError::RepeatedPoints))
-        ));
+        let res = kzg.batch_open(&p, &repeated_points);
+        let expected_error = KZGError::OperationError(OperationError::RepeatedPoints);
+
+        assert_eq!(res, Err(expected_error));
     }
 
     #[test]
     fn test_kzg_batch_open_and_verify() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -555,23 +526,24 @@ mod tests {
         let points = vec![Fr::from(6), Fr::from(11), Fr::from(17)];
         let expected_values = vec![Fr::from(10662), Fr::from(113562), Fr::from(626970)];
 
-        let proof = kzg.batch_open(&p, &points).unwrap();
+        let proof_res = kzg.batch_open(&p, &points);
+        assert!(proof_res.is_ok());
+        // TODO: Assert value
 
-        assert!(kzg
-            .batch_verify(commitment, &points, &expected_values, proof)
-            .unwrap());
+        let proof = proof_res.unwrap();
+        let res = kzg.batch_verify(commitment, &points, &expected_values, proof);
+        assert!(res.is_ok());
+
+        let v = res.unwrap();
+        assert!(v);
     }
 
     #[test]
     fn test_kzg_batch_verify_repeated_points() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 3 x^3 + 2 x^2 + x + 1
         let p = vec![Fr::from(1), Fr::from(1), Fr::from(2), Fr::from(3)];
@@ -585,23 +557,18 @@ mod tests {
         let points = vec![Fr::from(2), Fr::from(2)];
         let expected_values = vec![Fr::from(25), Fr::from(25)];
 
-        let result = kzg.batch_verify(commitment, &points, &expected_values, proof);
-        assert!(matches!(
-            result,
-            Err(KZGError::OperationError(OperationError::RepeatedPoints))
-        ));
+        let res = kzg.batch_verify(commitment, &points, &expected_values, proof);
+        let expected_error = KZGError::OperationError(OperationError::RepeatedPoints);
+
+        assert_eq!(res, Err(expected_error));
     }
 
     #[test]
     fn test_kzg_batch_verify_wrong_points() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -620,28 +587,24 @@ mod tests {
         let points = vec![Fr::from(6), Fr::from(11), Fr::from(17)];
         let expected_values = vec![Fr::from(10662), Fr::from(113562), Fr::from(626970)];
 
-        let correct_proof = kzg.batch_open(&p, &points).unwrap();
+        let proof = kzg.batch_open(&p, &points).unwrap();
+
+        let v_valid_point = kzg.batch_verify(commitment, &points, &expected_values, proof);
+        assert!(v_valid_point.is_ok());
+        assert_eq!(v_valid_point.unwrap(), true);
 
         let wrong_points = vec![Fr::from(7), Fr::from(11), Fr::from(17)];
-
-        assert!(!kzg
-            .batch_verify(commitment, &wrong_points, &expected_values, correct_proof)
-            .unwrap());
-        assert!(kzg
-            .batch_verify(commitment, &points, &expected_values, correct_proof)
-            .unwrap());
+        let v_wrong_points = kzg.batch_verify(commitment, &wrong_points, &expected_values, proof);
+        assert!(v_wrong_points.is_ok());
+        assert_eq!(v_wrong_points.unwrap(), false);
     }
 
     #[test]
     fn test_kzg_batch_verify_wrong_proof() {
         let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let max_degree = 4;
         let secret = Fr::rand(rng);
-
-        let kzg =
-            KZG::<Bls12_381>::setup(g1_generator.into(), g2_generator.into(), max_degree, secret);
+        let max_degree = 4;
+        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
         let p = vec![
@@ -660,7 +623,10 @@ mod tests {
         let points = vec![Fr::from(6), Fr::from(11), Fr::from(17)];
         let expected_values = vec![Fr::from(10662), Fr::from(113562), Fr::from(626970)];
 
-        let correct_proof = kzg.batch_open(&p, &points).unwrap();
+        let proof = kzg.batch_open(&p, &points).unwrap();
+        let v_valid_point = kzg.batch_verify(commitment, &points, &expected_values, proof);
+        assert!(v_valid_point.is_ok());
+        assert_eq!(v_valid_point.unwrap(), true);
 
         // Compute a proof for another polynomial
         // q(x) = 2 x^4 - 3 x^3 + x^2 + 5 x + 10
@@ -671,15 +637,10 @@ mod tests {
             Fr::from(-3),
             Fr::from(2),
         ];
-
         let fake_proof = kzg.batch_open(&q, &points).unwrap();
 
-        assert!(!kzg
-            .batch_verify(commitment, &points, &expected_values, fake_proof)
-            .unwrap());
-
-        assert!(kzg
-            .batch_verify(commitment, &points, &expected_values, correct_proof)
-            .unwrap());
+        let v_wrong_proof = kzg.batch_verify(commitment, &points, &expected_values, fake_proof);
+        assert!(v_wrong_proof.is_ok());
+        assert_eq!(v_wrong_proof.unwrap(), false);
     }
 }

--- a/src/kzg/setup.rs
+++ b/src/kzg/setup.rs
@@ -4,6 +4,8 @@
 //!
 //! The only supported format is the Snark JS `ptau` trusted setup file format.
 
+#![allow(clippy::type_complexity)]
+
 use ark_ec::{pairing::Pairing, AffineRepr};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress};
 use std::{

--- a/src/pol_op.rs
+++ b/src/pol_op.rs
@@ -168,7 +168,7 @@ pub fn lagrange_interpolation<E: Pairing>(
     Ok(result)
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum OperationError {
     #[error("Cannot divide by polynomial of higher degree.")]
     DenominatorTooLarge,

--- a/src/we.rs
+++ b/src/we.rs
@@ -94,7 +94,7 @@ impl<E: Pairing> WE<E> {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum WEError {
     #[error("Key Encapsulation Error {0}")]
     KEMError(KEMError),
@@ -106,125 +106,125 @@ impl From<KEMError> for WEError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::pol_op::evaluate_polynomial;
-    use ark_bls12_381::{Bls12_381, Fr, G1Projective, G2Projective};
-    use ark_std::test_rng;
-    use ark_std::UniformRand;
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use crate::pol_op::evaluate_polynomial;
+//     use ark_bls12_381::{Bls12_381, Fr, G1Projective, G2Projective};
+//     use ark_std::test_rng;
+//     use ark_std::UniformRand;
 
-    #[test]
-    fn test_encrypt_single() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let point: Fr = Fr::rand(rng);
-        let kzg = KZG::<Bls12_381>::setup(g1_gen, g2_gen, max_degree, secret);
-        let we: WE<Bls12_381> = WE::new(kzg);
+//     #[test]
+//     fn test_encrypt_single() {
+//         let rng = &mut test_rng();
+//         let g1_gen = G1Projective::rand(rng);
+//         let g2_gen = G2Projective::rand(rng);
+//         let secret = Fr::rand(rng);
+//         let max_degree = 10;
+//         let point: Fr = Fr::rand(rng);
+//         let kzg = KZG::<Bls12_381>::setup(g1_gen, g2_gen, max_degree, secret);
+//         let we: WE<Bls12_381> = WE::new(kzg);
 
-        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-        let commitment = we.kzg().commit(&p).unwrap();
+//         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+//         let p = vec![
+//             Fr::from(-24),
+//             Fr::from(-25),
+//             Fr::from(-5),
+//             Fr::from(9),
+//             Fr::from(7),
+//         ];
+//         let val = evaluate_polynomial::<Bls12_381>(&p, &point);
+//         let commitment = we.kzg().commit(&p).unwrap();
 
-        let msg = b"helloworld";
+//         let msg = b"helloworld";
 
-        let (key_ct, msg_ct) = we.encrypt_single(commitment, point, val, msg).unwrap();
+//         let (key_ct, msg_ct) = we.encrypt_single(commitment, point, val, msg).unwrap();
 
-        let proof = we.kzg().open(&p, &point).unwrap();
+//         let proof = we.kzg().open(&p, &point).unwrap();
 
-        let decrypted_msg = we.decrypt_single(proof, key_ct, &msg_ct).unwrap();
+//         let decrypted_msg = we.decrypt_single(proof, key_ct, &msg_ct).unwrap();
 
-        assert_eq!(msg.to_vec(), decrypted_msg);
-    }
+//         assert_eq!(msg.to_vec(), decrypted_msg);
+//     }
 
-    #[test]
-    fn test_decrypt_single_invalid_proof() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let point: Fr = Fr::rand(rng);
-        let kzg = KZG::<Bls12_381>::setup(g1_gen, g2_gen, max_degree, secret);
-        let we: WE<Bls12_381> = WE::new(kzg);
+//     #[test]
+//     fn test_decrypt_single_invalid_proof() {
+//         let rng = &mut test_rng();
+//         let g1_gen = G1Projective::rand(rng);
+//         let g2_gen = G2Projective::rand(rng);
+//         let secret = Fr::rand(rng);
+//         let max_degree = 10;
+//         let point: Fr = Fr::rand(rng);
+//         let kzg = KZG::<Bls12_381>::setup(g1_gen, g2_gen, max_degree, secret);
+//         let we: WE<Bls12_381> = WE::new(kzg);
 
-        // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let val = evaluate_polynomial::<Bls12_381>(&p, &point);
-        let commitment = we.kzg().commit(&p).unwrap();
+//         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
+//         let p = vec![
+//             Fr::from(-24),
+//             Fr::from(-25),
+//             Fr::from(-5),
+//             Fr::from(9),
+//             Fr::from(7),
+//         ];
+//         let val = evaluate_polynomial::<Bls12_381>(&p, &point);
+//         let commitment = we.kzg().commit(&p).unwrap();
 
-        let msg = b"helloworld";
-        let (key_ct, msg_ct) = we.encrypt_single(commitment, point, val, msg).unwrap();
+//         let msg = b"helloworld";
+//         let (key_ct, msg_ct) = we.encrypt_single(commitment, point, val, msg).unwrap();
 
-        let wrong_point: Fr = Fr::rand(rng);
-        let invalid_proof = we.kzg().open(&p, &wrong_point).unwrap();
+//         let wrong_point: Fr = Fr::rand(rng);
+//         let invalid_proof = we.kzg().open(&p, &wrong_point).unwrap();
 
-        let decrypted_msg = we.decrypt_single(invalid_proof, key_ct, &msg_ct).unwrap();
+//         let decrypted_msg = we.decrypt_single(invalid_proof, key_ct, &msg_ct).unwrap();
 
-        assert_ne!(msg.to_vec(), decrypted_msg);
-    }
+//         assert_ne!(msg.to_vec(), decrypted_msg);
+//     }
 
-    #[test]
-    fn test_encrypt_decrypt_single() {
-        let rng = &mut test_rng();
-        let g1_gen = G1Projective::rand(rng);
-        let g2_gen = G2Projective::rand(rng);
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(g1_gen, g2_gen, max_degree, secret);
-        let we: WE<Bls12_381> = WE::new(kzg);
+//     #[test]
+//     fn test_encrypt_decrypt_single() {
+//         let rng = &mut test_rng();
+//         let g1_gen = G1Projective::rand(rng);
+//         let g2_gen = G2Projective::rand(rng);
+//         let secret = Fr::rand(rng);
+//         let max_degree = 10;
+//         let kzg = KZG::<Bls12_381>::setup(g1_gen, g2_gen, max_degree, secret);
+//         let we: WE<Bls12_381> = WE::new(kzg);
 
-        let p = vec![
-            Fr::from(-24),
-            Fr::from(-25),
-            Fr::from(-5),
-            Fr::from(9),
-            Fr::from(7),
-        ];
-        let points = vec![Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
-        let values: Vec<Fr> = points
-            .iter()
-            .map(|&point| evaluate_polynomial::<Bls12_381>(&p, &point))
-            .collect();
-        let commitment = we.kzg().commit(&p).unwrap();
+//         let p = vec![
+//             Fr::from(-24),
+//             Fr::from(-25),
+//             Fr::from(-5),
+//             Fr::from(9),
+//             Fr::from(7),
+//         ];
+//         let points = vec![Fr::rand(rng), Fr::rand(rng), Fr::rand(rng)];
+//         let values: Vec<Fr> = points
+//             .iter()
+//             .map(|&point| evaluate_polynomial::<Bls12_381>(&p, &point))
+//             .collect();
+//         let commitment = we.kzg().commit(&p).unwrap();
 
-        let msg = b"helloworld";
+//         let msg = b"helloworld";
 
-        let cts = we
-            .encrypt(commitment, points.clone(), values.clone(), msg)
-            .unwrap();
+//         let cts = we
+//             .encrypt(commitment, points.clone(), values.clone(), msg)
+//             .unwrap();
 
-        let target_index = 1;
-        let proof = we.kzg().open(&p, &points[target_index]).unwrap();
+//         let target_index = 1;
+//         let proof = we.kzg().open(&p, &points[target_index]).unwrap();
 
-        let (correct_key_ct, correct_msg_ct) = &cts[target_index];
-        let decrypted_msg = we
-            .decrypt_single(proof, *correct_key_ct, correct_msg_ct)
-            .unwrap();
-        assert_eq!(msg.to_vec(), decrypted_msg);
+//         let (correct_key_ct, correct_msg_ct) = &cts[target_index];
+//         let decrypted_msg = we
+//             .decrypt_single(proof, *correct_key_ct, correct_msg_ct)
+//             .unwrap();
+//         assert_eq!(msg.to_vec(), decrypted_msg);
 
-        // Attempt to decrypt a different message with the same proof
-        let (wrong_key_ct, wrong_msg_ct) = &cts[0];
-        let wrong_decrypted_msg = we
-            .decrypt_single(proof, *wrong_key_ct, wrong_msg_ct)
-            .unwrap();
+//         // Attempt to decrypt a different message with the same proof
+//         let (wrong_key_ct, wrong_msg_ct) = &cts[0];
+//         let wrong_decrypted_msg = we
+//             .decrypt_single(proof, *wrong_key_ct, wrong_msg_ct)
+//             .unwrap();
 
-        assert_ne!(msg.to_vec(), wrong_decrypted_msg);
-    }
-}
+//         assert_ne!(msg.to_vec(), wrong_decrypted_msg);
+//     }
+// }

--- a/src/we.rs
+++ b/src/we.rs
@@ -113,13 +113,17 @@ mod tests {
     use ark_bls12_381::{Bls12_381, Fr};
     use ark_std::test_rng;
     use ark_std::UniformRand;
+    use rand::Rng;
+
+    fn setup_kzg(rng: &mut impl Rng) -> KZG<Bls12_381> {
+        let secret = Fr::rand(rng);
+        KZG::<Bls12_381>::setup(secret, 10)
+    }
 
     #[test]
     fn test_encrypt_single() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
         let we: WE<Bls12_381> = WE::new(kzg);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
@@ -149,9 +153,7 @@ mod tests {
     #[test]
     fn test_decrypt_single_invalid_proof() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
         let we: WE<Bls12_381> = WE::new(kzg);
 
         // p(x) = 7 x^4 + 9 x^3 - 5 x^2 - 25 x - 24
@@ -181,9 +183,7 @@ mod tests {
     #[test]
     fn test_encrypt_decrypt_single() {
         let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-        let max_degree = 10;
-        let kzg = KZG::<Bls12_381>::setup(secret, max_degree);
+        let kzg = setup_kzg(rng);
         let we: WE<Bls12_381> = WE::new(kzg);
 
         let p = vec![

--- a/tests/laconic_ot.rs
+++ b/tests/laconic_ot.rs
@@ -1,220 +1,214 @@
-// //! # Laconic OT
-// //!
-// //! This module contains the implementation of a Laconic Oblivious Transfer using we-kzg.
+//! # Laconic OT
+//!
+//! This module contains the implementation of a Laconic Oblivious Transfer using we-kzg.
 
-// use ark_ec::pairing::Pairing;
-// use ark_ff::Field;
-// use keaki::{
-//     kzg::KZGError,
-//     pol_op::evaluate_polynomial,
-//     we::{WEError, WE},
-// };
+use ark_ec::pairing::Pairing;
+use ark_ff::Field;
+use keaki::{
+    kzg::KZGError,
+    pol_op::evaluate_polynomial,
+    we::{WEError, WE},
+};
 
-// pub const SUCCESSFUL_DECRYPTION_PAD: usize = 32;
-// pub const SUCCESSFUL_DECRYPTION: &[u8] = &[0u8; SUCCESSFUL_DECRYPTION_PAD];
+pub const SUCCESSFUL_DECRYPTION_PAD: usize = 32;
+pub const SUCCESSFUL_DECRYPTION: &[u8] = &[0u8; SUCCESSFUL_DECRYPTION_PAD];
 
-// /// Laconic OT Receiver struct.
-// #[derive(Debug, Clone, Default, PartialEq, Eq)]
-// pub struct OTReceiver<E: Pairing> {
-//     we: WE<E>,
-//     selection: usize,
-// }
+/// Laconic OT Receiver struct.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OTReceiver<E: Pairing> {
+    we: WE<E>,
+    selection: usize,
+}
 
-// impl<E: Pairing> OTReceiver<E> {
-//     /// Creates a new instance.
-//     pub fn new(we: WE<E>, selection: usize) -> Self {
-//         Self { we, selection }
-//     }
+impl<E: Pairing> OTReceiver<E> {
+    /// Creates a new instance.
+    pub fn new(we: WE<E>, selection: usize) -> Self {
+        Self { we, selection }
+    }
 
-//     /// Commits to a selection polynomial.
-//     pub fn commit(&self) -> Result<E::G1, KZGError> {
-//         let selection_polynomial =
-//             get_selection_polynomial::<E>(self.selection, self.we.kzg().max_degree());
+    /// Commits to a selection polynomial.
+    pub fn commit(&self) -> Result<E::G1, KZGError> {
+        let selection_polynomial =
+            get_selection_polynomial::<E>(self.selection, self.we.kzg().g1_pow().len());
 
-//         self.we.kzg().commit(&selection_polynomial)
-//     }
+        self.we.kzg().commit(&selection_polynomial)
+    }
 
-//     /// Decrypts the sender's set of ciphertexts.
-//     pub fn decrypt(
-//         &self,
-//         encrypted_messages: Vec<(E::G2, Vec<u8>)>,
-//     ) -> Result<Vec<Vec<u8>>, WEError> {
-//         let selection_polynomial =
-//             get_selection_polynomial::<E>(self.selection, self.we.kzg().max_degree());
+    /// Decrypts the sender's set of ciphertexts.
+    pub fn decrypt(
+        &self,
+        encrypted_messages: Vec<(E::G2, Vec<u8>)>,
+    ) -> Result<Vec<Vec<u8>>, WEError> {
+        let selection_polynomial =
+            get_selection_polynomial::<E>(self.selection, self.we.kzg().g1_pow().len());
 
-//         // Generate proof
-//         let proof = self
-//             .we
-//             .kzg()
-//             .open(
-//                 &selection_polynomial,
-//                 &E::ScalarField::from(self.selection as u64),
-//             )
-//             .unwrap();
+        // Generate proof
+        let proof = self
+            .we
+            .kzg()
+            .open(
+                &selection_polynomial,
+                &E::ScalarField::from(self.selection as u64),
+            )
+            .unwrap();
 
-//         let mut decrypted_messages = Vec::new();
-//         for encrypted_message in encrypted_messages {
-//             let (key_ct, msg_ct) = encrypted_message;
+        let mut decrypted_messages = Vec::new();
+        for encrypted_message in encrypted_messages {
+            let (key_ct, msg_ct) = encrypted_message;
 
-//             let decrypted_msg = self.we.decrypt_single(proof, key_ct, &msg_ct)?;
-//             decrypted_messages.push(decrypted_msg);
-//         }
+            let decrypted_msg = self.we.decrypt_single(proof, key_ct, &msg_ct)?;
+            decrypted_messages.push(decrypted_msg);
+        }
 
-//         Ok(decrypted_messages)
-//     }
-// }
+        Ok(decrypted_messages)
+    }
+}
 
-// /// Laconic OT Sender struct.
-// #[derive(Debug, Clone, Default, PartialEq, Eq)]
-// pub struct OTSender<E: Pairing> {
-//     we: WE<E>,
-// }
+/// Laconic OT Sender struct.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OTSender<E: Pairing> {
+    we: WE<E>,
+}
 
-// impl<E: Pairing> OTSender<E> {
-//     /// Creates a new instance.
-//     pub fn new(we: WE<E>) -> Self {
-//         Self { we }
-//     }
+impl<E: Pairing> OTSender<E> {
+    /// Creates a new instance.
+    pub fn new(we: WE<E>) -> Self {
+        Self { we }
+    }
 
-//     /// Encrypts a set of values for a given commitment.
-//     /// - `values`: the list of values.
-//     /// - `commitment`: the commitment to the selection polynomial.
-//     fn encrypt(
-//         &self,
-//         values: &[&[u8]],
-//         commitment: E::G1,
-//     ) -> Result<Vec<(E::G2, Vec<u8>)>, WEError> {
-//         let message_pad = Vec::from(SUCCESSFUL_DECRYPTION);
+    /// Encrypts a set of values for a given commitment.
+    /// - `values`: the list of values.
+    /// - `commitment`: the commitment to the selection polynomial.
+    fn encrypt(
+        &self,
+        values: &[&[u8]],
+        commitment: E::G1,
+    ) -> Result<Vec<(E::G2, Vec<u8>)>, WEError> {
+        let message_pad = Vec::from(SUCCESSFUL_DECRYPTION);
 
-//         let mut encrypted_messages = Vec::new();
-//         for (index, &value) in values.iter().enumerate() {
-//             let mut message = message_pad.clone();
-//             message.extend(value);
+        let mut encrypted_messages = Vec::new();
+        for (index, &value) in values.iter().enumerate() {
+            let mut message = message_pad.clone();
+            message.extend(value);
 
-//             // Evaluate the polynomial
-//             let selection_polynomial =
-//                 get_selection_polynomial::<E>(index, self.we.kzg().max_degree());
-//             let evaluation = evaluate_polynomial::<E>(
-//                 &selection_polynomial,
-//                 &E::ScalarField::from(index as u64),
-//             );
+            // Evaluate the polynomial
+            let selection_polynomial =
+                get_selection_polynomial::<E>(index, self.we.kzg().g1_pow().len());
+            let evaluation = evaluate_polynomial::<E>(
+                &selection_polynomial,
+                &E::ScalarField::from(index as u64),
+            );
 
-//             let enc_message = self.we.encrypt_single(
-//                 commitment,
-//                 E::ScalarField::from(index as u64),
-//                 evaluation,
-//                 &message,
-//             )?;
+            let enc_message = self.we.encrypt_single(
+                commitment,
+                E::ScalarField::from(index as u64),
+                evaluation,
+                &message,
+            )?;
 
-//             encrypted_messages.push(enc_message);
-//         }
+            encrypted_messages.push(enc_message);
+        }
 
-//         Ok(encrypted_messages)
-//     }
-// }
+        Ok(encrypted_messages)
+    }
+}
 
-// /// Generates a selection polynomial from a selection and a max degree.
-// fn get_selection_polynomial<E: Pairing>(
-//     selection: usize,
-//     max_degree: usize,
-// ) -> Vec<E::ScalarField> {
-//     let mut selection_polynomial = vec![E::ScalarField::ZERO; max_degree];
-//     selection_polynomial[selection] = E::ScalarField::ONE;
-//     selection_polynomial
-// }
+/// Generates a selection polynomial from a selection and a max degree.
+fn get_selection_polynomial<E: Pairing>(
+    selection: usize,
+    max_degree: usize,
+) -> Vec<E::ScalarField> {
+    let mut selection_polynomial = vec![E::ScalarField::ZERO; max_degree];
+    selection_polynomial[selection] = E::ScalarField::ONE;
+    selection_polynomial
+}
 
-// #[cfg(test)]
-// mod laconic_ot_tests {
-//     use super::*;
-//     use ark_bls12_381::{
-//         g1::{G1_GENERATOR_X, G1_GENERATOR_Y},
-//         g2::{G2_GENERATOR_X, G2_GENERATOR_Y},
-//         Bls12_381, Fr, G1Affine, G2Affine,
-//     };
-//     use ark_std::{test_rng, UniformRand};
-//     use keaki::{kzg::KZG, we::WE};
-//     use rand::Rng;
+#[cfg(test)]
+mod laconic_ot_tests {
+    use super::*;
+    use ark_bls12_381::{Bls12_381, Fr};
+    use ark_std::{test_rng, UniformRand};
+    use keaki::{kzg::KZG, we::WE};
+    use rand::Rng;
 
-//     const MAX_DEGREE: usize = 4;
+    const MAX_DEGREE: usize = 4;
 
-//     /// Setups the KZG instance.
-//     fn setup_kzg() -> KZG<Bls12_381> {
-//         let rng = &mut test_rng();
-//         let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-//         let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-//         let secret = Fr::rand(rng);
+    /// Setups the KZG instance.
+    fn setup_kzg() -> KZG<Bls12_381> {
+        let rng = &mut test_rng();
+        let secret = Fr::rand(rng);
 
-//         KZG::setup(g1_generator.into(), g2_generator.into(), MAX_DEGREE, secret)
-//     }
+        KZG::<Bls12_381>::setup(secret, MAX_DEGREE)
+    }
 
-//     #[test]
-//     fn test_laconic_ot() {
-//         let rng = &mut test_rng();
-//         let kzg = setup_kzg();
-//         let we: WE<Bls12_381> = WE::new(kzg);
+    #[test]
+    fn test_laconic_ot() {
+        let rng = &mut test_rng();
+        let kzg = setup_kzg();
+        let we: WE<Bls12_381> = WE::new(kzg);
 
-//         // --------------------
-//         // ----- Receiver -----
-//         // --------------------
+        // --------------------
+        // ----- Receiver -----
+        // --------------------
 
-//         // Make a random selection
-//         let selection: usize = rng.gen_range(0..MAX_DEGREE);
+        // Make a random selection
+        let selection: usize = rng.gen_range(0..MAX_DEGREE);
 
-//         // Instantiate the Receiver
-//         let receiver = OTReceiver::new(we.clone(), selection);
+        // Instantiate the Receiver
+        let receiver = OTReceiver::new(we.clone(), selection);
 
-//         // Commit
-//         let commitment = receiver.commit().unwrap();
+        // Commit
+        let commitment = receiver.commit().unwrap();
 
-//         // --------------------
-//         // ------ Sender ------
-//         // --------------------
+        // --------------------
+        // ------ Sender ------
+        // --------------------
 
-//         // Generate 4 random values
-//         const VALUE_LENGTH: usize = 32;
-//         let mut values: Vec<&[u8]> = Vec::with_capacity(MAX_DEGREE);
+        // Generate 4 random values
+        const VALUE_LENGTH: usize = 32;
+        let mut values: Vec<&[u8]> = Vec::with_capacity(MAX_DEGREE);
 
-//         for _ in 0..MAX_DEGREE {
-//             let mut value: Vec<u8> = Vec::with_capacity(VALUE_LENGTH);
+        for _ in 0..MAX_DEGREE {
+            let mut value: Vec<u8> = Vec::with_capacity(VALUE_LENGTH);
 
-//             for _ in 0..VALUE_LENGTH {
-//                 let val: u8 = rng.gen();
+            for _ in 0..VALUE_LENGTH {
+                let val: u8 = rng.gen();
 
-//                 value.push(val);
-//             }
+                value.push(val);
+            }
 
-//             values.push(value.leak());
-//         }
+            values.push(value.leak());
+        }
 
-//         // Instantiate the Sender
-//         let sender = OTSender::new(we.clone());
+        // Instantiate the Sender
+        let sender = OTSender::new(we.clone());
 
-//         // Encrypt
-//         let encrypted_messages = sender.encrypt(&values, commitment).unwrap();
+        // Encrypt
+        let encrypted_messages = sender.encrypt(&values, commitment).unwrap();
 
-//         // --------------------
-//         // ----- Receiver -----
-//         // --------------------
+        // --------------------
+        // ----- Receiver -----
+        // --------------------
 
-//         // Decrypt
-//         let decrypted_messages = receiver.decrypt(encrypted_messages).unwrap();
+        // Decrypt
+        let decrypted_messages = receiver.decrypt(encrypted_messages).unwrap();
 
-//         let mut decrypted_values = Vec::new();
-//         for message in decrypted_messages {
-//             // Assert message length
-//             assert_eq!(message.len(), SUCCESSFUL_DECRYPTION_PAD + VALUE_LENGTH);
+        let mut decrypted_values = Vec::new();
+        for message in decrypted_messages {
+            // Assert message length
+            assert_eq!(message.len(), SUCCESSFUL_DECRYPTION_PAD + VALUE_LENGTH);
 
-//             if message.starts_with(SUCCESSFUL_DECRYPTION) {
-//                 let value: Vec<u8> = message[SUCCESSFUL_DECRYPTION.len()..].to_vec();
+            if message.starts_with(SUCCESSFUL_DECRYPTION) {
+                let value: Vec<u8> = message[SUCCESSFUL_DECRYPTION.len()..].to_vec();
 
-//                 decrypted_values.push(value);
-//             }
-//         }
+                decrypted_values.push(value);
+            }
+        }
 
-//         // Assert that the receiver can only decrypt the message corresponding to the selection
-//         assert_eq!(decrypted_values.len(), 1);
+        // Assert that the receiver can only decrypt the message corresponding to the selection
+        assert_eq!(decrypted_values.len(), 1);
 
-//         // Assert that the decrypted value is the same as the value at the selection index from the sender
-//         assert_eq!(decrypted_values[0], values[selection]);
-//     }
-// }
+        // Assert that the decrypted value is the same as the value at the selection index from the sender
+        assert_eq!(decrypted_values[0], values[selection]);
+    }
+}

--- a/tests/laconic_ot.rs
+++ b/tests/laconic_ot.rs
@@ -133,18 +133,11 @@ mod laconic_ot_tests {
 
     const MAX_DEGREE: usize = 4;
 
-    /// Setups the KZG instance.
-    fn setup_kzg() -> KZG<Bls12_381> {
-        let rng = &mut test_rng();
-        let secret = Fr::rand(rng);
-
-        KZG::<Bls12_381>::setup(secret, MAX_DEGREE)
-    }
-
     #[test]
     fn test_laconic_ot() {
         let rng = &mut test_rng();
-        let kzg = setup_kzg();
+        let secret = Fr::rand(rng);
+        let kzg = KZG::<Bls12_381>::setup(secret, MAX_DEGREE);
         let we: WE<Bls12_381> = WE::new(kzg);
 
         // --------------------

--- a/tests/laconic_ot.rs
+++ b/tests/laconic_ot.rs
@@ -1,220 +1,220 @@
-//! # Laconic OT
-//!
-//! This module contains the implementation of a Laconic Oblivious Transfer using we-kzg.
+// //! # Laconic OT
+// //!
+// //! This module contains the implementation of a Laconic Oblivious Transfer using we-kzg.
 
-use ark_ec::pairing::Pairing;
-use ark_ff::Field;
-use keaki::{
-    kzg::KZGError,
-    pol_op::evaluate_polynomial,
-    we::{WEError, WE},
-};
+// use ark_ec::pairing::Pairing;
+// use ark_ff::Field;
+// use keaki::{
+//     kzg::KZGError,
+//     pol_op::evaluate_polynomial,
+//     we::{WEError, WE},
+// };
 
-pub const SUCCESSFUL_DECRYPTION_PAD: usize = 32;
-pub const SUCCESSFUL_DECRYPTION: &[u8] = &[0u8; SUCCESSFUL_DECRYPTION_PAD];
+// pub const SUCCESSFUL_DECRYPTION_PAD: usize = 32;
+// pub const SUCCESSFUL_DECRYPTION: &[u8] = &[0u8; SUCCESSFUL_DECRYPTION_PAD];
 
-/// Laconic OT Receiver struct.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct OTReceiver<E: Pairing> {
-    we: WE<E>,
-    selection: usize,
-}
+// /// Laconic OT Receiver struct.
+// #[derive(Debug, Clone, Default, PartialEq, Eq)]
+// pub struct OTReceiver<E: Pairing> {
+//     we: WE<E>,
+//     selection: usize,
+// }
 
-impl<E: Pairing> OTReceiver<E> {
-    /// Creates a new instance.
-    pub fn new(we: WE<E>, selection: usize) -> Self {
-        Self { we, selection }
-    }
+// impl<E: Pairing> OTReceiver<E> {
+//     /// Creates a new instance.
+//     pub fn new(we: WE<E>, selection: usize) -> Self {
+//         Self { we, selection }
+//     }
 
-    /// Commits to a selection polynomial.
-    pub fn commit(&self) -> Result<E::G1, KZGError> {
-        let selection_polynomial =
-            get_selection_polynomial::<E>(self.selection, self.we.kzg().max_degree());
+//     /// Commits to a selection polynomial.
+//     pub fn commit(&self) -> Result<E::G1, KZGError> {
+//         let selection_polynomial =
+//             get_selection_polynomial::<E>(self.selection, self.we.kzg().max_degree());
 
-        self.we.kzg().commit(&selection_polynomial)
-    }
+//         self.we.kzg().commit(&selection_polynomial)
+//     }
 
-    /// Decrypts the sender's set of ciphertexts.
-    pub fn decrypt(
-        &self,
-        encrypted_messages: Vec<(E::G2, Vec<u8>)>,
-    ) -> Result<Vec<Vec<u8>>, WEError> {
-        let selection_polynomial =
-            get_selection_polynomial::<E>(self.selection, self.we.kzg().max_degree());
+//     /// Decrypts the sender's set of ciphertexts.
+//     pub fn decrypt(
+//         &self,
+//         encrypted_messages: Vec<(E::G2, Vec<u8>)>,
+//     ) -> Result<Vec<Vec<u8>>, WEError> {
+//         let selection_polynomial =
+//             get_selection_polynomial::<E>(self.selection, self.we.kzg().max_degree());
 
-        // Generate proof
-        let proof = self
-            .we
-            .kzg()
-            .open(
-                &selection_polynomial,
-                &E::ScalarField::from(self.selection as u64),
-            )
-            .unwrap();
+//         // Generate proof
+//         let proof = self
+//             .we
+//             .kzg()
+//             .open(
+//                 &selection_polynomial,
+//                 &E::ScalarField::from(self.selection as u64),
+//             )
+//             .unwrap();
 
-        let mut decrypted_messages = Vec::new();
-        for encrypted_message in encrypted_messages {
-            let (key_ct, msg_ct) = encrypted_message;
+//         let mut decrypted_messages = Vec::new();
+//         for encrypted_message in encrypted_messages {
+//             let (key_ct, msg_ct) = encrypted_message;
 
-            let decrypted_msg = self.we.decrypt_single(proof, key_ct, &msg_ct)?;
-            decrypted_messages.push(decrypted_msg);
-        }
+//             let decrypted_msg = self.we.decrypt_single(proof, key_ct, &msg_ct)?;
+//             decrypted_messages.push(decrypted_msg);
+//         }
 
-        Ok(decrypted_messages)
-    }
-}
+//         Ok(decrypted_messages)
+//     }
+// }
 
-/// Laconic OT Sender struct.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct OTSender<E: Pairing> {
-    we: WE<E>,
-}
+// /// Laconic OT Sender struct.
+// #[derive(Debug, Clone, Default, PartialEq, Eq)]
+// pub struct OTSender<E: Pairing> {
+//     we: WE<E>,
+// }
 
-impl<E: Pairing> OTSender<E> {
-    /// Creates a new instance.
-    pub fn new(we: WE<E>) -> Self {
-        Self { we }
-    }
+// impl<E: Pairing> OTSender<E> {
+//     /// Creates a new instance.
+//     pub fn new(we: WE<E>) -> Self {
+//         Self { we }
+//     }
 
-    /// Encrypts a set of values for a given commitment.
-    /// - `values`: the list of values.
-    /// - `commitment`: the commitment to the selection polynomial.
-    fn encrypt(
-        &self,
-        values: &[&[u8]],
-        commitment: E::G1,
-    ) -> Result<Vec<(E::G2, Vec<u8>)>, WEError> {
-        let message_pad = Vec::from(SUCCESSFUL_DECRYPTION);
+//     /// Encrypts a set of values for a given commitment.
+//     /// - `values`: the list of values.
+//     /// - `commitment`: the commitment to the selection polynomial.
+//     fn encrypt(
+//         &self,
+//         values: &[&[u8]],
+//         commitment: E::G1,
+//     ) -> Result<Vec<(E::G2, Vec<u8>)>, WEError> {
+//         let message_pad = Vec::from(SUCCESSFUL_DECRYPTION);
 
-        let mut encrypted_messages = Vec::new();
-        for (index, &value) in values.iter().enumerate() {
-            let mut message = message_pad.clone();
-            message.extend(value);
+//         let mut encrypted_messages = Vec::new();
+//         for (index, &value) in values.iter().enumerate() {
+//             let mut message = message_pad.clone();
+//             message.extend(value);
 
-            // Evaluate the polynomial
-            let selection_polynomial =
-                get_selection_polynomial::<E>(index, self.we.kzg().max_degree());
-            let evaluation = evaluate_polynomial::<E>(
-                &selection_polynomial,
-                &E::ScalarField::from(index as u64),
-            );
+//             // Evaluate the polynomial
+//             let selection_polynomial =
+//                 get_selection_polynomial::<E>(index, self.we.kzg().max_degree());
+//             let evaluation = evaluate_polynomial::<E>(
+//                 &selection_polynomial,
+//                 &E::ScalarField::from(index as u64),
+//             );
 
-            let enc_message = self.we.encrypt_single(
-                commitment,
-                E::ScalarField::from(index as u64),
-                evaluation,
-                &message,
-            )?;
+//             let enc_message = self.we.encrypt_single(
+//                 commitment,
+//                 E::ScalarField::from(index as u64),
+//                 evaluation,
+//                 &message,
+//             )?;
 
-            encrypted_messages.push(enc_message);
-        }
+//             encrypted_messages.push(enc_message);
+//         }
 
-        Ok(encrypted_messages)
-    }
-}
+//         Ok(encrypted_messages)
+//     }
+// }
 
-/// Generates a selection polynomial from a selection and a max degree.
-fn get_selection_polynomial<E: Pairing>(
-    selection: usize,
-    max_degree: usize,
-) -> Vec<E::ScalarField> {
-    let mut selection_polynomial = vec![E::ScalarField::ZERO; max_degree];
-    selection_polynomial[selection] = E::ScalarField::ONE;
-    selection_polynomial
-}
+// /// Generates a selection polynomial from a selection and a max degree.
+// fn get_selection_polynomial<E: Pairing>(
+//     selection: usize,
+//     max_degree: usize,
+// ) -> Vec<E::ScalarField> {
+//     let mut selection_polynomial = vec![E::ScalarField::ZERO; max_degree];
+//     selection_polynomial[selection] = E::ScalarField::ONE;
+//     selection_polynomial
+// }
 
-#[cfg(test)]
-mod laconic_ot_tests {
-    use super::*;
-    use ark_bls12_381::{
-        g1::{G1_GENERATOR_X, G1_GENERATOR_Y},
-        g2::{G2_GENERATOR_X, G2_GENERATOR_Y},
-        Bls12_381, Fr, G1Affine, G2Affine,
-    };
-    use ark_std::{test_rng, UniformRand};
-    use keaki::{kzg::KZG, we::WE};
-    use rand::Rng;
+// #[cfg(test)]
+// mod laconic_ot_tests {
+//     use super::*;
+//     use ark_bls12_381::{
+//         g1::{G1_GENERATOR_X, G1_GENERATOR_Y},
+//         g2::{G2_GENERATOR_X, G2_GENERATOR_Y},
+//         Bls12_381, Fr, G1Affine, G2Affine,
+//     };
+//     use ark_std::{test_rng, UniformRand};
+//     use keaki::{kzg::KZG, we::WE};
+//     use rand::Rng;
 
-    const MAX_DEGREE: usize = 4;
+//     const MAX_DEGREE: usize = 4;
 
-    /// Setups the KZG instance.
-    fn setup_kzg() -> KZG<Bls12_381> {
-        let rng = &mut test_rng();
-        let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
-        let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
-        let secret = Fr::rand(rng);
+//     /// Setups the KZG instance.
+//     fn setup_kzg() -> KZG<Bls12_381> {
+//         let rng = &mut test_rng();
+//         let g1_generator = G1Affine::new(G1_GENERATOR_X, G1_GENERATOR_Y);
+//         let g2_generator = G2Affine::new(G2_GENERATOR_X, G2_GENERATOR_Y);
+//         let secret = Fr::rand(rng);
 
-        KZG::setup(g1_generator.into(), g2_generator.into(), MAX_DEGREE, secret)
-    }
+//         KZG::setup(g1_generator.into(), g2_generator.into(), MAX_DEGREE, secret)
+//     }
 
-    #[test]
-    fn test_laconic_ot() {
-        let rng = &mut test_rng();
-        let kzg = setup_kzg();
-        let we: WE<Bls12_381> = WE::new(kzg);
+//     #[test]
+//     fn test_laconic_ot() {
+//         let rng = &mut test_rng();
+//         let kzg = setup_kzg();
+//         let we: WE<Bls12_381> = WE::new(kzg);
 
-        // --------------------
-        // ----- Receiver -----
-        // --------------------
+//         // --------------------
+//         // ----- Receiver -----
+//         // --------------------
 
-        // Make a random selection
-        let selection: usize = rng.gen_range(0..MAX_DEGREE);
+//         // Make a random selection
+//         let selection: usize = rng.gen_range(0..MAX_DEGREE);
 
-        // Instantiate the Receiver
-        let receiver = OTReceiver::new(we.clone(), selection);
+//         // Instantiate the Receiver
+//         let receiver = OTReceiver::new(we.clone(), selection);
 
-        // Commit
-        let commitment = receiver.commit().unwrap();
+//         // Commit
+//         let commitment = receiver.commit().unwrap();
 
-        // --------------------
-        // ------ Sender ------
-        // --------------------
+//         // --------------------
+//         // ------ Sender ------
+//         // --------------------
 
-        // Generate 4 random values
-        const VALUE_LENGTH: usize = 32;
-        let mut values: Vec<&[u8]> = Vec::with_capacity(MAX_DEGREE);
+//         // Generate 4 random values
+//         const VALUE_LENGTH: usize = 32;
+//         let mut values: Vec<&[u8]> = Vec::with_capacity(MAX_DEGREE);
 
-        for _ in 0..MAX_DEGREE {
-            let mut value: Vec<u8> = Vec::with_capacity(VALUE_LENGTH);
+//         for _ in 0..MAX_DEGREE {
+//             let mut value: Vec<u8> = Vec::with_capacity(VALUE_LENGTH);
 
-            for _ in 0..VALUE_LENGTH {
-                let val: u8 = rng.gen();
+//             for _ in 0..VALUE_LENGTH {
+//                 let val: u8 = rng.gen();
 
-                value.push(val);
-            }
+//                 value.push(val);
+//             }
 
-            values.push(value.leak());
-        }
+//             values.push(value.leak());
+//         }
 
-        // Instantiate the Sender
-        let sender = OTSender::new(we.clone());
+//         // Instantiate the Sender
+//         let sender = OTSender::new(we.clone());
 
-        // Encrypt
-        let encrypted_messages = sender.encrypt(&values, commitment).unwrap();
+//         // Encrypt
+//         let encrypted_messages = sender.encrypt(&values, commitment).unwrap();
 
-        // --------------------
-        // ----- Receiver -----
-        // --------------------
+//         // --------------------
+//         // ----- Receiver -----
+//         // --------------------
 
-        // Decrypt
-        let decrypted_messages = receiver.decrypt(encrypted_messages).unwrap();
+//         // Decrypt
+//         let decrypted_messages = receiver.decrypt(encrypted_messages).unwrap();
 
-        let mut decrypted_values = Vec::new();
-        for message in decrypted_messages {
-            // Assert message length
-            assert_eq!(message.len(), SUCCESSFUL_DECRYPTION_PAD + VALUE_LENGTH);
+//         let mut decrypted_values = Vec::new();
+//         for message in decrypted_messages {
+//             // Assert message length
+//             assert_eq!(message.len(), SUCCESSFUL_DECRYPTION_PAD + VALUE_LENGTH);
 
-            if message.starts_with(SUCCESSFUL_DECRYPTION) {
-                let value: Vec<u8> = message[SUCCESSFUL_DECRYPTION.len()..].to_vec();
+//             if message.starts_with(SUCCESSFUL_DECRYPTION) {
+//                 let value: Vec<u8> = message[SUCCESSFUL_DECRYPTION.len()..].to_vec();
 
-                decrypted_values.push(value);
-            }
-        }
+//                 decrypted_values.push(value);
+//             }
+//         }
 
-        // Assert that the receiver can only decrypt the message corresponding to the selection
-        assert_eq!(decrypted_values.len(), 1);
+//         // Assert that the receiver can only decrypt the message corresponding to the selection
+//         assert_eq!(decrypted_values.len(), 1);
 
-        // Assert that the decrypted value is the same as the value at the selection index from the sender
-        assert_eq!(decrypted_values[0], values[selection]);
-    }
-}
+//         // Assert that the decrypted value is the same as the value at the selection index from the sender
+//         assert_eq!(decrypted_values[0], values[selection]);
+//     }
+// }


### PR DESCRIPTION
# Description

This PR features a restructuring of the KZG module. It removes some fields from the structs and has some updates to the error handling. 

It also adds the `new_from_file` method to the struct, to adapt to #5.