### PR TITLE
Add working laconic OT test

### DIFF
--- a/tests/laconic_ot.rs
+++ b/tests/laconic_ot.rs
@@ -67,7 +67,6 @@ impl<E: Pairing> Receiver<E> {
             we,
             boolean_choices,
             commitment,
-            selection_polynomial,
             proofs, // Store the precomputed proofs
         }
     }

--- a/tests/laconic_ot.rs
+++ b/tests/laconic_ot.rs
@@ -22,7 +22,6 @@ pub type CiphertextTuple<E> = (Ciphertext<E>, Ciphertext<E>);
 pub struct Receiver<E: Pairing> {
     we: WE<E>,
     boolean_choices: Vec<E::ScalarField>,
-    selection_polynomial: Vec<E::ScalarField>,
     commitment: E::G1,
     proofs: Vec<E::G1>, // New field to store precomputed proofs
 }

--- a/tests/laconic_ot.rs
+++ b/tests/laconic_ot.rs
@@ -4,137 +4,164 @@
 
 use ark_ec::pairing::Pairing;
 use ark_ff::Field;
+use ark_std::UniformRand;
 use keaki::{
-    kzg::KZGError,
-    pol_op::evaluate_polynomial,
+    pol_op::lagrange_interpolation,
     we::{WEError, WE},
 };
+use rand::thread_rng;
+use std::time::Instant;
 
-pub const SUCCESSFUL_DECRYPTION_PAD: usize = 32;
-pub const SUCCESSFUL_DECRYPTION: &[u8] = &[0u8; SUCCESSFUL_DECRYPTION_PAD];
+/// Type alias for the plaintext tuple
+pub type PlaintextTuple = (Vec<u8>, Vec<u8>);
+/// Type alias for a single ciphertext
+pub type Ciphertext<E> = (<E as Pairing>::G2, Vec<u8>);
+/// Type alias for the ciphertext tuple
+pub type CiphertextTuple<E> = (Ciphertext<E>, Ciphertext<E>);
 
-/// Laconic OT Receiver struct.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct OTReceiver<E: Pairing> {
+pub struct Receiver<E: Pairing> {
     we: WE<E>,
-    selection: usize,
+    boolean_choices: Vec<E::ScalarField>,
+    selection_polynomial: Vec<E::ScalarField>,
+    commitment: E::G1,
+    proofs: Vec<E::G1>, // New field to store precomputed proofs
 }
 
-impl<E: Pairing> OTReceiver<E> {
-    /// Creates a new instance.
-    pub fn new(we: WE<E>, selection: usize) -> Self {
-        Self { we, selection }
-    }
+impl<E: Pairing> Receiver<E> {
+    pub fn setup(we: WE<E>, boolean_choices: Vec<E::ScalarField>) -> Self {
+        // pad with random evaluations to blind polynomial
+        let ck_len = we.kzg().g1_pow().len();
+        let pad_len = ck_len - boolean_choices.len();
+        let pad = (0..pad_len)
+            .map(|_| E::ScalarField::rand(&mut thread_rng()))
+            .collect();
+        let evaluations = [boolean_choices.clone(), pad].concat();
 
-    /// Commits to a selection polynomial.
-    pub fn commit(&self) -> Result<E::G1, KZGError> {
-        let selection_polynomial =
-            get_selection_polynomial::<E>(self.selection, self.we.kzg().g1_pow().len());
+        // interpolate polynomial
+        let interpolation_start = Instant::now();
+        let points: Vec<E::ScalarField> = (0..ck_len)
+            .map(|i| E::ScalarField::from(i as u64))
+            .collect();
+        let selection_polynomial = lagrange_interpolation::<E>(&points, &evaluations).unwrap();
+        let interpolation_time = interpolation_start.elapsed();
+        println!("Interpolation time: {:?}", interpolation_time);
 
-        self.we.kzg().commit(&selection_polynomial)
-    }
+        // commit to polynomial
+        let commitment_start = Instant::now();
+        let commitment = we.kzg().commit(&selection_polynomial).unwrap();
+        let commitment_time = commitment_start.elapsed();
+        println!("Commitment time: {:?}", commitment_time);
 
-    /// Decrypts the sender's set of ciphertexts.
-    pub fn decrypt(
-        &self,
-        encrypted_messages: Vec<(E::G2, Vec<u8>)>,
-    ) -> Result<Vec<Vec<u8>>, WEError> {
-        let selection_polynomial =
-            get_selection_polynomial::<E>(self.selection, self.we.kzg().g1_pow().len());
+        // Generate proofs for each index
+        let proof_gen_start = Instant::now();
+        let proofs: Vec<E::G1> = (0..boolean_choices.len())
+            .map(|index| {
+                we.kzg()
+                    .open(&selection_polynomial, &E::ScalarField::from(index as u64))
+                    .unwrap()
+            })
+            .collect();
+        let proof_gen_time = proof_gen_start.elapsed();
+        println!("Proof generation time: {:?}", proof_gen_time);
 
-        // Generate proof
-        let proof = self
-            .we
-            .kzg()
-            .open(
-                &selection_polynomial,
-                &E::ScalarField::from(self.selection as u64),
-            )
-            .unwrap();
-
-        let mut decrypted_messages = Vec::new();
-        for encrypted_message in encrypted_messages {
-            let (key_ct, msg_ct) = encrypted_message;
-
-            let decrypted_msg = self.we.decrypt_single(proof, key_ct, &msg_ct)?;
-            decrypted_messages.push(decrypted_msg);
+        Self {
+            we,
+            boolean_choices,
+            commitment,
+            selection_polynomial,
+            proofs, // Store the precomputed proofs
         }
+    }
+
+    pub fn receive(
+        &self,
+        encrypted_keys: Vec<CiphertextTuple<E>>,
+    ) -> Result<Vec<Vec<u8>>, WEError> {
+        let mut decrypted_messages = Vec::new();
+        let mut total_decryption_time = std::time::Duration::new(0, 0);
+
+        for (index, encrypted_key) in encrypted_keys.iter().enumerate() {
+            // Use the precomputed proof
+            let proof = self.proofs[index];
+
+            // chose ciphertext to decrypt based on boolean choice
+            let (key_ct, msg_ct) = if self.boolean_choices[index] == E::ScalarField::ZERO {
+                encrypted_key.0.clone()
+            } else {
+                encrypted_key.1.clone()
+            };
+
+            // decrypt message
+            let decryption_start = Instant::now();
+            let decrypted_message = self.we.decrypt_single(proof, key_ct, &msg_ct).unwrap();
+            total_decryption_time += decryption_start.elapsed();
+            decrypted_messages.push(decrypted_message);
+        }
+
+        // Remove the total_proof_gen_time print statement
+        println!("Total decryption time: {:?}", total_decryption_time);
 
         Ok(decrypted_messages)
     }
 }
 
-/// Laconic OT Sender struct.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct OTSender<E: Pairing> {
+pub struct Sender<E: Pairing> {
     we: WE<E>,
 }
 
-impl<E: Pairing> OTSender<E> {
-    /// Creates a new instance.
-    pub fn new(we: WE<E>) -> Self {
+impl<E: Pairing> Sender<E> {
+    pub fn setup(we: WE<E>) -> Self {
         Self { we }
     }
 
-    /// Encrypts a set of values for a given commitment.
-    /// - `values`: the list of values.
-    /// - `commitment`: the commitment to the selection polynomial.
-    fn encrypt(
+    pub fn send(
         &self,
-        values: &[&[u8]],
+        circuit_keys: Vec<PlaintextTuple>,
         commitment: E::G1,
-    ) -> Result<Vec<(E::G2, Vec<u8>)>, WEError> {
-        let message_pad = Vec::from(SUCCESSFUL_DECRYPTION);
-
+    ) -> Result<Vec<CiphertextTuple<E>>, WEError> {
         let mut encrypted_messages = Vec::new();
-        for (index, &value) in values.iter().enumerate() {
-            let mut message = message_pad.clone();
-            message.extend(value);
+        let encryption_start = Instant::now();
 
-            // Evaluate the polynomial
-            let selection_polynomial =
-                get_selection_polynomial::<E>(index, self.we.kzg().g1_pow().len());
-            let evaluation = evaluate_polynomial::<E>(
-                &selection_polynomial,
-                &E::ScalarField::from(index as u64),
-            );
-
-            let enc_message = self.we.encrypt_single(
+        for (index, value) in circuit_keys.iter().enumerate() {
+            let enc_message_0 = self.we.encrypt_single(
                 commitment,
                 E::ScalarField::from(index as u64),
-                evaluation,
-                &message,
+                E::ScalarField::ZERO,
+                &value.0,
             )?;
 
-            encrypted_messages.push(enc_message);
+            let enc_message_1 = self.we.encrypt_single(
+                commitment,
+                E::ScalarField::from(index as u64),
+                E::ScalarField::ONE,
+                &value.1,
+            )?;
+
+            encrypted_messages.push((enc_message_0, enc_message_1));
         }
+
+        let encryption_time = encryption_start.elapsed();
+        println!("Encryption time: {:?}", encryption_time);
 
         Ok(encrypted_messages)
     }
 }
 
-/// Generates a selection polynomial from a selection and a max degree.
-fn get_selection_polynomial<E: Pairing>(
-    selection: usize,
-    max_degree: usize,
-) -> Vec<E::ScalarField> {
-    let mut selection_polynomial = vec![E::ScalarField::ZERO; max_degree];
-    selection_polynomial[selection] = E::ScalarField::ONE;
-    selection_polynomial
-}
-
 #[cfg(test)]
-mod laconic_ot_tests {
+mod new_laconic_ot_tests {
     use super::*;
     use ark_bls12_381::{Bls12_381, Fr};
     use ark_std::{test_rng, UniformRand};
     use keaki::{kzg::KZG, we::WE};
     use rand::Rng;
 
-    const MAX_DEGREE: usize = 4;
+    const MAX_DEGREE: usize = 32;
+    const NUM_OT_VALUES: usize = 32;
 
     #[test]
     fn test_laconic_ot() {
+        // Setup KZG commitment scheme
         let rng = &mut test_rng();
         let secret = Fr::rand(rng);
         let kzg = KZG::<Bls12_381>::setup(secret, MAX_DEGREE);
@@ -144,64 +171,59 @@ mod laconic_ot_tests {
         // ----- Receiver -----
         // --------------------
 
-        // Make a random selection
-        let selection: usize = rng.gen_range(0..MAX_DEGREE);
+        // Receiver's boolean choices
+        let boolean_choices: Vec<Fr> = (0..NUM_OT_VALUES)
+            .map(|_| if rng.gen_bool(0.5) { Fr::ONE } else { Fr::ZERO })
+            .collect();
 
-        // Instantiate the Receiver
-        let receiver = OTReceiver::new(we.clone(), selection);
-
-        // Commit
-        let commitment = receiver.commit().unwrap();
+        let receiver_setup_start = Instant::now();
+        let receiver = Receiver::setup(we.clone(), boolean_choices.clone());
+        let receiver_setup_time = receiver_setup_start.elapsed();
+        println!("Receiver setup time: {:?}\n", receiver_setup_time);
 
         // --------------------
         // ------ Sender ------
         // --------------------
 
-        // Generate 4 random values
+        // Set up pairs of circuit keys for receiver to choose from
         const VALUE_LENGTH: usize = 32;
-        let mut values: Vec<&[u8]> = Vec::with_capacity(MAX_DEGREE);
+        let circuit_keys: Vec<PlaintextTuple> = (0..NUM_OT_VALUES)
+            .map(|_| {
+                (
+                    (0..VALUE_LENGTH).map(|_| rng.gen()).collect(),
+                    (0..VALUE_LENGTH).map(|_| rng.gen()).collect(),
+                )
+            })
+            .collect();
+        let sender = Sender::setup(we);
 
-        for _ in 0..MAX_DEGREE {
-            let mut value: Vec<u8> = Vec::with_capacity(VALUE_LENGTH);
-
-            for _ in 0..VALUE_LENGTH {
-                let val: u8 = rng.gen();
-
-                value.push(val);
-            }
-
-            values.push(value.leak());
-        }
-
-        // Instantiate the Sender
-        let sender = OTSender::new(we.clone());
-
-        // Encrypt
-        let encrypted_messages = sender.encrypt(&values, commitment).unwrap();
+        // Encrypt the pairs of circuit keys using receiver's commitment
+        let sender_send_start = Instant::now();
+        let encrypted_messages = sender
+            .send(circuit_keys.clone(), receiver.commitment)
+            .unwrap();
+        let sender_send_time = sender_send_start.elapsed();
+        println!("Sender send time: {:?}\n", sender_send_time);
 
         // --------------------
         // ----- Receiver -----
         // --------------------
 
-        // Decrypt
-        let decrypted_messages = receiver.decrypt(encrypted_messages).unwrap();
+        // Decrypt the pairs of ciphertexts using the receiver's boolean choice
+        let receiver_receive_start = Instant::now();
+        let decrypted_messages = receiver.receive(encrypted_messages).unwrap();
+        let receiver_receive_time = receiver_receive_start.elapsed();
+        println!("Receiver receive time: {:?}\n", receiver_receive_time);
 
-        let mut decrypted_values = Vec::new();
-        for message in decrypted_messages {
-            // Assert message length
-            assert_eq!(message.len(), SUCCESSFUL_DECRYPTION_PAD + VALUE_LENGTH);
+        // Verify correctness of decrypted messages
+        for (i, decrypted_message) in decrypted_messages.iter().enumerate() {
+            let expected_value = if boolean_choices[i] == Fr::ZERO {
+                &circuit_keys[i].0
+            } else {
+                &circuit_keys[i].1
+            };
 
-            if message.starts_with(SUCCESSFUL_DECRYPTION) {
-                let value: Vec<u8> = message[SUCCESSFUL_DECRYPTION.len()..].to_vec();
-
-                decrypted_values.push(value);
-            }
+            assert_eq!(decrypted_message, expected_value, "Mismatch at index {}", i);
         }
-
-        // Assert that the receiver can only decrypt the message corresponding to the selection
-        assert_eq!(decrypted_values.len(), 1);
-
-        // Assert that the decrypted value is the same as the value at the selection index from the sender
-        assert_eq!(decrypted_values[0], values[selection]);
     }
 }


### PR DESCRIPTION
Updating the old laconic OT test:
- Adding multiple boolean selections as receiver
- Adding random evaluation points to blind the selection polynomial
- Interpolating this set of evaluation points + KZG committing
- Generating all the opening proofs for the boolean selections
- Sender handles encryptions for all of the selections
- Receiver handles decryption of all values

I was originally planning on generating Lagrange bases polynomials from the powers of tau and doing O(N) time computation of the KZG polynomial commitment. But then I realized that generating all the opening proofs would still naively be O(N^2) without using the [FK algorithm](https://alinush.github.io/2021/06/17/Feist-Khovratovich-technique-for-computing-KZG-proofs-fast.html) so I didn't bother.

Right now, on a polynomial of degree 32, the commitment process has a 60x overhead and the sending/receiving processes (meaning the encryption and decryption of 32 different values) have 30x overhead on the paper's original implementation. So I think it won't be performant enough to use in browser in the short-term.